### PR TITLE
Add multilingual support for blog, FAQ, and features editing

### DIFF
--- a/Services/Repository/IBlogRepository.cs
+++ b/Services/Repository/IBlogRepository.cs
@@ -46,6 +46,7 @@ namespace Services
         public bool Delete(int ID);
         public BlogCrudViewModel GetModelForCreate();
         public BlogCrudViewModel GetByID(int BlogID);
+        public void SaveTranslations(BlogCrudViewModel blog);
         public BlogCommentsPageDataViewModel GetNewsComments(string q = "", int PageID = 1);
         public BlogCommentsPageDataViewModel GetNewsConfirmComments(string q = "", int PageID = 1);
         public BlogCommentsPageDataViewModel GetNewsAnswerComments(string q = "", int PageID = 1);

--- a/Services/Repository/IFaqsRepository.cs
+++ b/Services/Repository/IFaqsRepository.cs
@@ -23,6 +23,7 @@ namespace Services
         public bool Create(FaqsCrudViewModel faqs);
         public bool Update(FaqsCrudViewModel faqs);
         public bool Delete(int FaqID);
+        public void SaveTranslations(FaqsCrudViewModel faqs);
 
         public PaginationViewModel GetPagination(double PageCount, int PageID = 1);
 

--- a/Services/Repository/IFeaturesRepository.cs
+++ b/Services/Repository/IFeaturesRepository.cs
@@ -18,10 +18,12 @@ namespace Services
         public List<BlogItemViewModel> GetRelatedNews(int FeatureID);
 
         public Feature GetByID(int id);
+        public FeatureCrudViewModel GetForEdit(int id);
         public bool Create(Feature feature , IFormFile ImageName , IFormFile AnimateFile , IFormFile FirstArticleImage , IFormFile SecondArticleImage, IFormFile IntroduceImage);
         public bool Update(Feature feature , IFormFile ImageName , IFormFile AnimateFile , IFormFile FirstArticleImage , IFormFile SecondArticleImage , IFormFile IntroduceImage);
         public bool Update(Feature feature , IFormFile IntroduceImage);
         public bool Delete(Feature feature);
+        public void SaveTranslations(FeatureCrudViewModel feature);
         public AdminFeaturesPageDataViewModel GetAdminFeatures(string q = "" , int PageID =1);
         public PaginationViewModel GetPagination(double PageCount, int PageID = 1);
 
@@ -31,9 +33,11 @@ namespace Services
         public List<Feature> GetFeatureIntroduces();
 
         public FeatureItem GetItemByID(int ItemID);
+        public FeatureItemCrudViewModel GetItemForEdit(int ItemID);
         public bool CreateItem(FeatureItem featureItem , IFormFile formFile);
         public bool UpdateItem(FeatureItem featureItem , IFormFile formFile);
         public bool DeleteItem(FeatureItem featureItem);
+        public void SaveItemTranslations(FeatureItemCrudViewModel item);
 
         public List<FeatureIconsViewModel> GetFeaturesIcons(int featureID);
     }

--- a/Services/Services/BlogRepository.cs
+++ b/Services/Services/BlogRepository.cs
@@ -1053,6 +1053,7 @@ namespace Services
                 };
                 db.Blogs.Add(model);
                 db.SaveChanges();
+                blog.BlogID = model.BlogId;
 
                 var tags = blog.Tags.Split('،').ToList();
 
@@ -1199,6 +1200,28 @@ namespace Services
                 SelectedGroups = db.SelectedBlogGroups.Where(s => s.BlogId == BlogID).Select(s => s.BlogGroupId).ToList()
             };
 
+            var trEn = db.BlogTranslations.FirstOrDefault(t => t.BlogId == BlogID && t.Language == "en");
+            var trAr = db.BlogTranslations.FirstOrDefault(t => t.BlogId == BlogID && t.Language == "ar");
+            var trUr = db.BlogTranslations.FirstOrDefault(t => t.BlogId == BlogID && t.Language == "ur");
+            if (trEn != null)
+            {
+                model.TitleEn = trEn.Title;
+                model.ShortDescriptionEn = trEn.ShortDescription;
+                model.DescriptionEn = trEn.Description;
+            }
+            if (trAr != null)
+            {
+                model.TitleAr = trAr.Title;
+                model.ShortDescriptionAr = trAr.ShortDescription;
+                model.DescriptionAr = trAr.Description;
+            }
+            if (trUr != null)
+            {
+                model.TitleUr = trUr.Title;
+                model.ShortDescriptionUr = trUr.ShortDescription;
+                model.DescriptionUr = trUr.Description;
+            }
+
             var groups = db.BlogGroups.ToList();
             model.Groups = new List<BlogGroupNameViewModel>();
             foreach (var item in groups)
@@ -1210,6 +1233,31 @@ namespace Services
                 });
             }
             return model;
+        }
+
+        public void SaveTranslations(BlogCrudViewModel blog)
+        {
+            SaveBlogTranslation(blog.BlogID, "en", blog.TitleEn, blog.ShortDescriptionEn, blog.DescriptionEn);
+            SaveBlogTranslation(blog.BlogID, "ar", blog.TitleAr, blog.ShortDescriptionAr, blog.DescriptionAr);
+            SaveBlogTranslation(blog.BlogID, "ur", blog.TitleUr, blog.ShortDescriptionUr, blog.DescriptionUr);
+        }
+
+        private void SaveBlogTranslation(int blogId, string lang, string title, string shortDescription, string description)
+        {
+            if (string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(shortDescription) && string.IsNullOrWhiteSpace(description))
+            {
+                return;
+            }
+            var tr = db.BlogTranslations.FirstOrDefault(t => t.BlogId == blogId && t.Language == lang);
+            if (tr == null)
+            {
+                tr = new BlogTranslation { BlogId = blogId, Language = lang };
+                db.BlogTranslations.Add(tr);
+            }
+            tr.Title = title ?? "";
+            tr.ShortDescription = shortDescription ?? "";
+            tr.Description = description ?? "";
+            db.SaveChanges();
         }
 
         #region NewsCrud

--- a/Services/Services/FaqsRepository.cs
+++ b/Services/Services/FaqsRepository.cs
@@ -165,6 +165,24 @@ namespace Services
                 Question = faq.Question,
                 IsMain = faq.IsMain
             };
+            var trEn = db.FaqTranslations.FirstOrDefault(t => t.FaqId == FaqID && t.Language == "en");
+            var trAr = db.FaqTranslations.FirstOrDefault(t => t.FaqId == FaqID && t.Language == "ar");
+            var trUr = db.FaqTranslations.FirstOrDefault(t => t.FaqId == FaqID && t.Language == "ur");
+            if (trEn != null)
+            {
+                model.QuestionEn = trEn.Question;
+                model.AnswerEn = trEn.Answer;
+            }
+            if (trAr != null)
+            {
+                model.QuestionAr = trAr.Question;
+                model.AnswerAr = trAr.Answer;
+            }
+            if (trUr != null)
+            {
+                model.QuestionUr = trUr.Question;
+                model.AnswerUr = trUr.Answer;
+            }
             var groups = db.FaqGroups.ToList();
             model.Groups = new List<FaqsGroupsItemViewModel>();
             foreach (var group in groups)
@@ -178,6 +196,30 @@ namespace Services
             var selectedGroups = db.SelectedFaqGroups.Where(f => f.FaqId == FaqID).Select(f => f.FaqGroupId).ToList();
             model.SelectedGroups = selectedGroups;
             return model;
+        }
+
+        public void SaveTranslations(FaqsCrudViewModel faqs)
+        {
+            SaveFaqTranslation(faqs.FaqID, "en", faqs.QuestionEn, faqs.AnswerEn);
+            SaveFaqTranslation(faqs.FaqID, "ar", faqs.QuestionAr, faqs.AnswerAr);
+            SaveFaqTranslation(faqs.FaqID, "ur", faqs.QuestionUr, faqs.AnswerUr);
+        }
+
+        private void SaveFaqTranslation(int faqId, string lang, string question, string answer)
+        {
+            if (string.IsNullOrWhiteSpace(question) && string.IsNullOrWhiteSpace(answer))
+            {
+                return;
+            }
+            var tr = db.FaqTranslations.FirstOrDefault(t => t.FaqId == faqId && t.Language == lang);
+            if (tr == null)
+            {
+                tr = new FaqTranslation { FaqId = faqId, Language = lang };
+                db.FaqTranslations.Add(tr);
+            }
+            tr.Question = question ?? "";
+            tr.Answer = answer ?? "";
+            db.SaveChanges();
         }
 
         public bool Create(FaqsCrudViewModel faqs)
@@ -196,6 +238,7 @@ namespace Services
                 };
                 db.Faqs.Add(faq);
                 db.SaveChanges();
+                faqs.FaqID = faq.FaqId;
                 foreach (var item in faqs.SelectedGroups)
                 {
                     var selected = new SelectedFaqGroup() { FaqId = faq.FaqId , FaqGroupId = item };

--- a/Services/Services/FeaturesRepository.cs
+++ b/Services/Services/FeaturesRepository.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -180,6 +181,27 @@ namespace Services
             return item;
         }
 
+        public FeatureItemCrudViewModel GetItemForEdit(int ItemID)
+        {
+            var item = db.FeatureItems.Find(ItemID);
+            var model = new FeatureItemCrudViewModel
+            {
+                FeaturesItemId = item.FeaturesItemId,
+                FeatureId = item.FeatureId,
+                Title = item.Title,
+                ShortDescription = item.ShortDescription,
+                ImageName = item.ImageName
+            };
+            var tr = db.EntityTranslations.ToList();
+            model.TitleEn = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "Title" && t.Culture == "en")?.Value;
+            model.TitleAr = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "Title" && t.Culture == "ar")?.Value;
+            model.TitleUr = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "Title" && t.Culture == "ur")?.Value;
+            model.ShortDescriptionEn = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "ShortDescription" && t.Culture == "en")?.Value;
+            model.ShortDescriptionAr = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "ShortDescription" && t.Culture == "ar")?.Value;
+            model.ShortDescriptionUr = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "ShortDescription" && t.Culture == "ur")?.Value;
+            return model;
+        }
+
         public bool CreateItem(FeatureItem featureItem, IFormFile ImageName)
         {
             try
@@ -252,6 +274,16 @@ namespace Services
             }
         }
 
+        public void SaveItemTranslations(FeatureItemCrudViewModel item)
+        {
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "Title", "en", item.TitleEn);
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "Title", "ar", item.TitleAr);
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "Title", "ur", item.TitleUr);
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "ShortDescription", "en", item.ShortDescriptionEn);
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "ShortDescription", "ar", item.ShortDescriptionAr);
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "ShortDescription", "ur", item.ShortDescriptionUr);
+        }
+
         public bool Create(Feature feature, IFormFile ImageName, IFormFile AnimateFile, IFormFile FirstArticleImage, IFormFile SecondArticleImage ,  IFormFile IntroduceImage)
         {
             try
@@ -309,6 +341,50 @@ namespace Services
         public Feature GetByID(int id)
         {
             return db.Features.Find(id);
+        }
+
+        public FeatureCrudViewModel GetForEdit(int id)
+        {
+            var feature = db.Features.Find(id);
+            var model = new FeatureCrudViewModel
+            {
+                FeatureId = feature.FeatureId,
+                Title = feature.Title,
+                ShortDescription = feature.ShortDescription,
+                FirstDescription = feature.FirstDescription,
+                FirstArticleTitle = feature.FirstArticleTitle,
+                FirstArticleDescription = feature.FirstArticleDescription,
+                SecondArticleTitle = feature.SecondArticleTitle,
+                SecondArticleDescription = feature.SecondArticleDescription,
+                ImageName = feature.ImageName,
+                AnimateFilename = feature.AnimateFilename,
+                FirstArticleImage = feature.FirstArticleImage,
+                SecondArticleImage = feature.SecondArticleImage,
+                IntroduceImageName = feature.IntroduceImageName
+            };
+            var tr = db.EntityTranslations.ToList();
+            model.TitleEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "Title" && t.Culture == "en")?.Value;
+            model.TitleAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "Title" && t.Culture == "ar")?.Value;
+            model.TitleUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "Title" && t.Culture == "ur")?.Value;
+            model.ShortDescriptionEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "ShortDescription" && t.Culture == "en")?.Value;
+            model.ShortDescriptionAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "ShortDescription" && t.Culture == "ar")?.Value;
+            model.ShortDescriptionUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "ShortDescription" && t.Culture == "ur")?.Value;
+            model.FirstDescriptionEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstDescription" && t.Culture == "en")?.Value;
+            model.FirstDescriptionAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstDescription" && t.Culture == "ar")?.Value;
+            model.FirstDescriptionUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstDescription" && t.Culture == "ur")?.Value;
+            model.FirstArticleTitleEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleTitle" && t.Culture == "en")?.Value;
+            model.FirstArticleTitleAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleTitle" && t.Culture == "ar")?.Value;
+            model.FirstArticleTitleUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleTitle" && t.Culture == "ur")?.Value;
+            model.FirstArticleDescriptionEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleDescription" && t.Culture == "en")?.Value;
+            model.FirstArticleDescriptionAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleDescription" && t.Culture == "ar")?.Value;
+            model.FirstArticleDescriptionUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleDescription" && t.Culture == "ur")?.Value;
+            model.SecondArticleTitleEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleTitle" && t.Culture == "en")?.Value;
+            model.SecondArticleTitleAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleTitle" && t.Culture == "ar")?.Value;
+            model.SecondArticleTitleUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleTitle" && t.Culture == "ur")?.Value;
+            model.SecondArticleDescriptionEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleDescription" && t.Culture == "en")?.Value;
+            model.SecondArticleDescriptionAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleDescription" && t.Culture == "ar")?.Value;
+            model.SecondArticleDescriptionUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleDescription" && t.Culture == "ur")?.Value;
+            return model;
         }
 
         public bool Update(Feature feature, IFormFile ImageName, IFormFile AnimateFile, IFormFile FirstArticleImage, IFormFile SecondArticleImage, IFormFile IntroduceImage)
@@ -424,6 +500,31 @@ namespace Services
             {
                 return false;
             }
+        }
+
+        public void SaveTranslations(FeatureCrudViewModel feature)
+        {
+            SaveTranslation("Feature", feature.FeatureId, "Title", "en", feature.TitleEn);
+            SaveTranslation("Feature", feature.FeatureId, "Title", "ar", feature.TitleAr);
+            SaveTranslation("Feature", feature.FeatureId, "Title", "ur", feature.TitleUr);
+            SaveTranslation("Feature", feature.FeatureId, "ShortDescription", "en", feature.ShortDescriptionEn);
+            SaveTranslation("Feature", feature.FeatureId, "ShortDescription", "ar", feature.ShortDescriptionAr);
+            SaveTranslation("Feature", feature.FeatureId, "ShortDescription", "ur", feature.ShortDescriptionUr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstDescription", "en", feature.FirstDescriptionEn);
+            SaveTranslation("Feature", feature.FeatureId, "FirstDescription", "ar", feature.FirstDescriptionAr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstDescription", "ur", feature.FirstDescriptionUr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleTitle", "en", feature.FirstArticleTitleEn);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleTitle", "ar", feature.FirstArticleTitleAr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleTitle", "ur", feature.FirstArticleTitleUr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleDescription", "en", feature.FirstArticleDescriptionEn);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleDescription", "ar", feature.FirstArticleDescriptionAr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleDescription", "ur", feature.FirstArticleDescriptionUr);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleTitle", "en", feature.SecondArticleTitleEn);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleTitle", "ar", feature.SecondArticleTitleAr);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleTitle", "ur", feature.SecondArticleTitleUr);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleDescription", "en", feature.SecondArticleDescriptionEn);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleDescription", "ar", feature.SecondArticleDescriptionAr);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleDescription", "ur", feature.SecondArticleDescriptionUr);
         }
 
         public bool Delete(Feature feature)
@@ -543,6 +644,28 @@ namespace Services
             return db.Features.ToList();
         }
 
-        
+        private void SaveTranslation(string entityName, int entityId, string property, string culture, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return;
+            }
+            var tr = db.EntityTranslations.FirstOrDefault(t => t.EntityName == entityName && t.EntityId == entityId && t.Property == property && t.Culture == culture);
+            if (tr == null)
+            {
+                tr = new EntityTranslation
+                {
+                    EntityName = entityName,
+                    EntityId = entityId,
+                    Property = property,
+                    Culture = culture
+                };
+                db.EntityTranslations.Add(tr);
+            }
+            tr.Value = value;
+            db.SaveChanges();
+        }
+
+
     }
 }

--- a/Services/Services/LocalizationExtensions.cs
+++ b/Services/Services/LocalizationExtensions.cs
@@ -15,6 +15,10 @@ namespace Services
             var culture = CultureInfo.CurrentUICulture.Name;
             var entityName = typeof(T).Name;
             var idProp = typeof(T).GetProperties().FirstOrDefault(p => p.Name == entityName + "Id");
+            if (idProp == null)
+            {
+                idProp = typeof(T).GetProperties().FirstOrDefault(p => p.Name.EndsWith("Id", StringComparison.OrdinalIgnoreCase) && p.PropertyType == typeof(int));
+            }
             if (idProp == null) return;
             var id = (int)(idProp.GetValue(entity) ?? 0);
             var translations = db.EntityTranslations

--- a/Twelve/Areas/Admin/Controllers/BlogController.cs
+++ b/Twelve/Areas/Admin/Controllers/BlogController.cs
@@ -102,6 +102,7 @@ namespace Twelve.Areas.Admin.Controllers
             }
             if (blogRepository.Create(blog,imageProduct))
             {
+                blogRepository.SaveTranslations(blog);
                 return RedirectToAction("Index");
             }
             else
@@ -138,6 +139,7 @@ namespace Twelve.Areas.Admin.Controllers
             }
             if (blogRepository.Update(blog , imageProduct))
             {
+                blogRepository.SaveTranslations(blog);
                 return RedirectToAction("Index");
             }
             else

--- a/Twelve/Areas/Admin/Controllers/FaqController.cs
+++ b/Twelve/Areas/Admin/Controllers/FaqController.cs
@@ -52,6 +52,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (faqsRepository.Create(faqs))
             {
+                faqsRepository.SaveTranslations(faqs);
                 return RedirectToAction("Index");
             }
             else
@@ -82,6 +83,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (faqsRepository.Update(faqs))
             {
+                faqsRepository.SaveTranslations(faqs);
                 return RedirectToAction("Index");
             }
             else

--- a/Twelve/Areas/Admin/Controllers/FeaturesController.cs
+++ b/Twelve/Areas/Admin/Controllers/FeaturesController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Services;
+using ViewModels;
 
 namespace Twelve.Areas.Admin.Controllers
 {
@@ -51,7 +52,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "ویژگی ها"))
             {
-                return View();
+                return View(new FeatureCrudViewModel());
             }
             else
             {
@@ -61,32 +62,43 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Create")]
-        public IActionResult Create(Feature feature, IFormFile imageProduct, IFormFile animeteFile, IFormFile imageFAProduct, IFormFile imageSAProduct , IFormFile introduceProduct)
+        public IActionResult Create(FeatureCrudViewModel feature, IFormFile imageProduct, IFormFile animeteFile, IFormFile imageFAProduct, IFormFile imageSAProduct , IFormFile introduceProduct)
         {
             if (imageProduct == null)
             {
                 ViewBag.Message = "لطفا تصویر مربوطه را وارد کنید";
-                return View();
+                return View(feature);
             }
             if (animeteFile == null)
             {
                 ViewBag.Message = "لطفا فایل انیمیشن مربوطه را وارد کنید";
-                return View();
+                return View(feature);
             }
             if (introduceProduct == null)
             {
                 ViewBag.Message = "لطفا تصویر معرفی نرم افزار در صفحه اول مربوطه را وارد کنید";
-                return View();
+                return View(feature);
             }
-
-            if (featuresRepository.Create(feature, imageProduct,animeteFile,imageFAProduct,imageSAProduct,introduceProduct))
+            var entity = new Feature
             {
+                Title = feature.Title,
+                ShortDescription = feature.ShortDescription,
+                FirstDescription = feature.FirstDescription,
+                FirstArticleTitle = feature.FirstArticleTitle,
+                FirstArticleDescription = feature.FirstArticleDescription,
+                SecondArticleTitle = feature.SecondArticleTitle,
+                SecondArticleDescription = feature.SecondArticleDescription
+            };
+            if (featuresRepository.Create(entity, imageProduct, animeteFile, imageFAProduct, imageSAProduct, introduceProduct))
+            {
+                feature.FeatureId = entity.FeatureId;
+                featuresRepository.SaveTranslations(feature);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                return View();
+                return View(feature);
             }
         }
 
@@ -95,7 +107,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "ویژگی ها"))
             {
-                var content = featuresRepository.GetByID(featureID);
+                var content = featuresRepository.GetForEdit(featureID);
                 return View(content);
             }
             else
@@ -106,16 +118,33 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Update/{FeatureID}")]
-        public IActionResult Update(Feature feature, IFormFile imageProduct, IFormFile animeteFile, IFormFile imageFAProduct, IFormFile imageSAProduct, IFormFile introduceProduct)
+        public IActionResult Update(FeatureCrudViewModel feature, IFormFile imageProduct, IFormFile animeteFile, IFormFile imageFAProduct, IFormFile imageSAProduct, IFormFile introduceProduct)
         {
-            if (featuresRepository.Update(feature, imageProduct, animeteFile, imageFAProduct, imageSAProduct, introduceProduct))
+            var entity = new Feature
             {
+                FeatureId = feature.FeatureId,
+                Title = feature.Title,
+                ShortDescription = feature.ShortDescription,
+                FirstDescription = feature.FirstDescription,
+                FirstArticleTitle = feature.FirstArticleTitle,
+                FirstArticleDescription = feature.FirstArticleDescription,
+                SecondArticleTitle = feature.SecondArticleTitle,
+                SecondArticleDescription = feature.SecondArticleDescription,
+                ImageName = feature.ImageName,
+                AnimateFilename = feature.AnimateFilename,
+                FirstArticleImage = feature.FirstArticleImage,
+                SecondArticleImage = feature.SecondArticleImage,
+                IntroduceImageName = feature.IntroduceImageName
+            };
+            if (featuresRepository.Update(entity, imageProduct, animeteFile, imageFAProduct, imageSAProduct, introduceProduct))
+            {
+                featuresRepository.SaveTranslations(feature);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = featuresRepository.GetByID(feature.FeatureId);
+                var content = featuresRepository.GetForEdit(feature.FeatureId);
                 return View(content);
             }
         }
@@ -204,7 +233,7 @@ namespace Twelve.Areas.Admin.Controllers
             if (adminRepository.CheckPermission(User.Identity.Name, "ویژگی ها"))
             {
                 ViewBag.FeatureID = FeatureID;
-                return View();
+                return View(new FeatureItemCrudViewModel { FeatureId = FeatureID });
             }
             else
             {
@@ -214,17 +243,25 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("CreateItem/{FeatureID}")]
-        public IActionResult CreateItem(FeatureItem featureItem, IFormFile imageProduct)
+        public IActionResult CreateItem(FeatureItemCrudViewModel featureItem, IFormFile imageProduct)
         {
-            if (featuresRepository.CreateItem(featureItem, imageProduct))
+            var entity = new FeatureItem
             {
+                FeatureId = featureItem.FeatureId,
+                Title = featureItem.Title,
+                ShortDescription = featureItem.ShortDescription
+            };
+            if (featuresRepository.CreateItem(entity, imageProduct))
+            {
+                featureItem.FeaturesItemId = entity.FeaturesItemId;
+                featuresRepository.SaveItemTranslations(featureItem);
                 return RedirectToAction("ShowItems", new { FeatureID = featureItem.FeatureId });
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
                 ViewBag.FeatureID = featureItem.FeatureId;
-                return View();
+                return View(featureItem);
             }
         }
 
@@ -233,7 +270,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "ویژگی ها"))
             {
-                var content = featuresRepository.GetItemByID(InfoID);
+                var content = featuresRepository.GetItemForEdit(InfoID);
                 return View(content);
             }
             else
@@ -244,16 +281,25 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("UpdateItem/{InfoID}")]
-        public IActionResult UpdateItem(FeatureItem featureItem, IFormFile imageProduct)
+        public IActionResult UpdateItem(FeatureItemCrudViewModel featureItem, IFormFile imageProduct)
         {
-            if (featuresRepository.UpdateItem(featureItem, imageProduct))
+            var entity = new FeatureItem
             {
+                FeaturesItemId = featureItem.FeaturesItemId,
+                FeatureId = featureItem.FeatureId,
+                Title = featureItem.Title,
+                ShortDescription = featureItem.ShortDescription,
+                ImageName = featureItem.ImageName
+            };
+            if (featuresRepository.UpdateItem(entity, imageProduct))
+            {
+                featuresRepository.SaveItemTranslations(featureItem);
                 return RedirectToAction("ShowItems", new { FeatureID = featureItem.FeatureId });
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = featuresRepository.GetItemByID(featureItem.FeaturesItemId);
+                var content = featuresRepository.GetItemForEdit(featureItem.FeaturesItemId);
                 return View(content);
             }
         }

--- a/Twelve/Areas/Admin/Views/Blog/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/Blog/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model ViewModels.BlogCrudViewModel
+@model ViewModels.BlogCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -16,21 +16,72 @@
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-9">
-                                    <div class="form-group">
-                                        <label for="Title">عنوان</label>
-                                        <input type="text" class="form-control w-100" name="Title" id="Title" placeholder="عنوان را وارد کنید"/>
-                                        @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="ShortDescription">توضیح کوتاه</label>
-                                        <textarea rows="5" class="form-control w-100" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید"></textarea>
-                                        @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
-
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="Description">متن</label>
-                                        <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="متن را وارد کنید"></textarea>
-                                        @Html.ValidationMessageFor(model => model.Description, "", new { @class = "text-danger" })
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" class="form-control w-100" name="Title" id="Title" placeholder="عنوان را وارد کنید" />
+                                                @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescription">توضیح کوتاه</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید"></textarea>
+                                                @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="Description">متن</label>
+                                                <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="متن را وارد کنید"></textarea>
+                                                @Html.ValidationMessageFor(model => model.Description, "", new { @class = "text-danger" })
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleEn" id="TitleEn" value="@Model?.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionEn">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionEn" id="ShortDescriptionEn">@Model?.ShortDescriptionEn</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionEn">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionEn" id="DescriptionEn">@Model?.DescriptionEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleAr" id="TitleAr" value="@Model?.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionAr">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionAr" id="ShortDescriptionAr">@Model?.ShortDescriptionAr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionAr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionAr" id="DescriptionAr">@Model?.DescriptionAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleUr" id="TitleUr" value="@Model?.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionUr">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionUr" id="ShortDescriptionUr">@Model?.ShortDescriptionUr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionUr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionUr" id="DescriptionUr">@Model?.DescriptionUr</textarea>
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="form-group ">
                                         <div class="text-center">
@@ -53,7 +104,7 @@
                                     </div>
                                     <div class="form-group">
                                         <label for="StudyTime">زمان مطالعه (دقیقه)</label>
-                                        <input type="number" min="1" value="1" class="form-control w-100" name="StudyTime" id="StudyTime"  />
+                                        <input type="number" min="1" value="1" class="form-control w-100" name="StudyTime" id="StudyTime" />
                                     </div>
                                     <div class="form-check">
                                         @Html.CheckBoxFor(model => model.IsSlider,htmlAttributes: new {@class="form-check-input"})
@@ -96,6 +147,9 @@
     <script>
         $(function () {
             $('#Description').ckeditor();
+            $('#DescriptionEn').ckeditor();
+            $('#DescriptionAr').ckeditor();
+            $('#DescriptionUr').ckeditor();
         });
     </script>
 }

--- a/Twelve/Areas/Admin/Views/Blog/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/Blog/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model ViewModels.BlogCrudViewModel
+@model ViewModels.BlogCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -18,17 +18,69 @@
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-9">
-                                    <div class="form-group">
-                                        <label for="Title">عنوان</label>
-                                        <input type="text" class="form-control w-100" value="@Model.Title"  name="Title" id="Title" placeholder="عنوان را وارد کنید" />
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="ShortDescription">توضیح کوتاه</label>
-                                        <textarea rows="5" class="form-control w-100" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">@Model.ShortDescription</textarea>
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="Description">متن</label>
-                                        <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="متن را وارد کنید">@Model.Description</textarea>
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" class="form-control w-100" value="@Model.Title" name="Title" id="Title" placeholder="عنوان را وارد کنید" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescription">توضیح کوتاه</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">@Model.ShortDescription</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="Description">متن</label>
+                                                <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="متن را وارد کنید">@Model.Description</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleEn" id="TitleEn" value="@Model.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionEn">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionEn" id="ShortDescriptionEn">@Model.ShortDescriptionEn</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionEn">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionEn" id="DescriptionEn">@Model.DescriptionEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleAr" id="TitleAr" value="@Model.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionAr">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionAr" id="ShortDescriptionAr">@Model.ShortDescriptionAr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionAr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionAr" id="DescriptionAr">@Model.DescriptionAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleUr" id="TitleUr" value="@Model.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionUr">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionUr" id="ShortDescriptionUr">@Model.ShortDescriptionUr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionUr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionUr" id="DescriptionUr">@Model.DescriptionUr</textarea>
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="form-group ">
                                         <div class="text-center">
@@ -78,7 +130,6 @@
                             </div>
                         </div>
                         <!-- /.card-body -->
-
                         <div class="card-footer">
                             <button type="submit" class="btn btn-warning">ثبت</button>
                             <a href="/Admin/Blog" class="btn btn-info float-left">بازگشت به لیست</a>
@@ -94,6 +145,9 @@
     <script>
         $(function () {
             $('#Description').ckeditor();
+            $('#DescriptionEn').ckeditor();
+            $('#DescriptionAr').ckeditor();
+            $('#DescriptionUr').ckeditor();
         });
     </script>
 }

--- a/Twelve/Areas/Admin/Views/Faq/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/Faq/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model ViewModels.FaqsCrudViewModel
+@model ViewModels.FaqsCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -16,13 +16,53 @@
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-9">
-                                    <div class="form-group">
-                                        <label for="Question">سوال</label>
-                                        <textarea rows="5" class="form-control w-100" name="Question" id="Question" placeholder="سوال را وارد کنید"></textarea>
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="Answer">پاسخ</label>
-                                        <textarea rows="5" class="form-control w-100" name="Answer" id="Answer" placeholder="پاسخ را وارد کنید"></textarea>
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Question">سوال</label>
+                                                <textarea rows="5" class="form-control w-100" name="Question" id="Question" placeholder="سوال را وارد کنید"></textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="Answer">پاسخ</label>
+                                                <textarea rows="5" class="form-control w-100" name="Answer" id="Answer" placeholder="پاسخ را وارد کنید"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionEn">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionEn" id="QuestionEn"></textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerEn">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerEn" id="AnswerEn"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionAr">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionAr" id="QuestionAr"></textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerAr">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerAr" id="AnswerAr"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionUr">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionUr" id="QuestionUr"></textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerUr">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerUr" id="AnswerUr"></textarea>
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="form-check">
                                         @Html.CheckBoxFor(model => model.IsMain,htmlAttributes: new {@class="form-check-input"})
@@ -49,7 +89,6 @@
                             </div>
                         </div>
                         <!-- /.card-body -->
-
                         <div class="card-footer">
                             <button type="submit" class="btn btn-success">ثبت</button>
                             <a href="/Admin/Faq" class="btn btn-info float-left">بازگشت به لیست</a>

--- a/Twelve/Areas/Admin/Views/Faq/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/Faq/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model ViewModels.FaqsCrudViewModel
+@model ViewModels.FaqsCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -13,17 +13,57 @@
                     <!-- /.card-header -->
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
-                        @Html.HiddenFor(m=> m.FaqID)
+                        @Html.HiddenFor(m => m.FaqID)
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-9">
-                                    <div class="form-group">
-                                        <label for="Question">سوال</label>
-                                        <textarea rows="5" class="form-control w-100" name="Question" id="Question" placeholder="سوال را وارد کنید">@Model.Question</textarea>
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="Answer">پاسخ</label>
-                                        <textarea rows="5" class="form-control w-100" name="Answer" id="Answer" placeholder="پاسخ را وارد کنید">@Model.Answer</textarea>
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Question">سوال</label>
+                                                <textarea rows="5" class="form-control w-100" name="Question" id="Question" placeholder="سوال را وارد کنید">@Model.Question</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="Answer">پاسخ</label>
+                                                <textarea rows="5" class="form-control w-100" name="Answer" id="Answer" placeholder="پاسخ را وارد کنید">@Model.Answer</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionEn">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionEn" id="QuestionEn">@Model.QuestionEn</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerEn">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerEn" id="AnswerEn">@Model.AnswerEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionAr">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionAr" id="QuestionAr">@Model.QuestionAr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerAr">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerAr" id="AnswerAr">@Model.AnswerAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionUr">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionUr" id="QuestionUr">@Model.QuestionUr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerUr">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerUr" id="AnswerUr">@Model.AnswerUr</textarea>
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="form-check">
                                         @Html.CheckBoxFor(model => model.IsMain,htmlAttributes: new {@class="form-check-input"})
@@ -50,9 +90,8 @@
                             </div>
                         </div>
                         <!-- /.card-body -->
-
                         <div class="card-footer">
-                            <button type="submit" class="btn btn-success">ثبت</button>
+                            <button type="submit" class="btn btn-warning">ثبت</button>
                             <a href="/Admin/Faq" class="btn btn-info float-left">بازگشت به لیست</a>
                         </div>
                     </form>

--- a/Twelve/Areas/Admin/Views/Features/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/Features/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.Feature
+@model ViewModels.FeatureCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -14,22 +14,76 @@
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" id="Title" placeholder="عنوان را وارد کنید">
-                                @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
-
-                            </div>
-                            <div class="form-group">
-                                <label for="ShortDescription">توضیح کوتاه</label>
-                                <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
-                                @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
-
-                            </div>
-                            <div class="form-group">
-                                <label for="FirstDescription">توضیح</label>
-                                <textarea rows="5" class="form-control w-100" name="FirstDescription" id="FirstDescription" placeholder="توضیح را وارد کنید"></textarea>
-                                @Html.ValidationMessageFor(model => model.FirstDescription, "", new { @class = "text-danger" })
+                            <div class="row">
+                                <div class="col-12">
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" name="Title" class="form-control" id="Title" value="@Model?.Title" placeholder="عنوان را وارد کنید">
+                                                @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescription">توضیح کوتاه</label>
+                                                <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" value="@Model?.ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                                                @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
+                                            </div>
+                        <div class="form-group">
+                                                <label for="FirstDescription">توضیح</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescription" id="FirstDescription" placeholder="توضیح را وارد کنید">@Model?.FirstDescription</textarea>
+                                                @Html.ValidationMessageFor(model => model.FirstDescription, "", new { @class = "text-danger" })
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model?.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionEn">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionEn" id="ShortDescriptionEn" value="@Model?.ShortDescriptionEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionEn">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionEn" id="FirstDescriptionEn">@Model?.FirstDescriptionEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model?.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionAr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionAr" id="ShortDescriptionAr" value="@Model?.ShortDescriptionAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionAr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionAr" id="FirstDescriptionAr">@Model?.FirstDescriptionAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model?.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionUr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionUr" id="ShortDescriptionUr" value="@Model?.ShortDescriptionUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionUr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionUr" id="FirstDescriptionUr">@Model?.FirstDescriptionUr</textarea>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">
@@ -67,11 +121,11 @@
                                 </div>
                                 <div class="form-group m-3">
                                     <label for="FirstArticleTitle">عنوان مقاله اول</label>
-                                    <input type="text" class="form-control" name="FirstArticleTitle" id="FirstArticleTitle" placeholder="عنوان مقاله اول را وارد کنید">
+                                    <input type="text" class="form-control" name="FirstArticleTitle" id="FirstArticleTitle" value="@Model?.FirstArticleTitle" placeholder="عنوان مقاله اول را وارد کنید">
                                 </div>
                                 <div class="form-group m-3">
                                     <label for="FirstArticleDescription">توضیح مقاله اول</label>
-                                    <textarea rows="5" class="form-control w-100" name="FirstArticleDescription" id="FirstArticleDescription" placeholder="توضیح مقاله اول را وارد کنید"></textarea>
+                                    <textarea rows="5" class="form-control w-100" name="FirstArticleDescription" id="FirstArticleDescription" placeholder="توضیح مقاله اول را وارد کنید">@Model?.FirstArticleDescription</textarea>
                                 </div>
                                 <div class="form-group m-3 ">
                                     <div class="text-center">
@@ -91,11 +145,11 @@
                                 </div>
                                 <div class="form-group m-3">
                                     <label for="SecondArticleTitle">عنوان مقاله دوم</label>
-                                    <input type="text" class="form-control" name="SecondArticleTitle" id="SecondArticleTitle" placeholder="عنوان مقاله دوم را وارد کنید">
+                                    <input type="text" class="form-control" name="SecondArticleTitle" id="SecondArticleTitle" value="@Model?.SecondArticleTitle" placeholder="عنوان مقاله دوم را وارد کنید">
                                 </div>
                                 <div class="form-group m-3">
                                     <label for="SecondArticleDescription">توضیح مقاله دوم</label>
-                                    <textarea rows="5" class="form-control w-100" name="SecondArticleDescription" id="SecondArticleDescription" placeholder="توضیح مقاله دوم را وارد کنید"></textarea>
+                                    <textarea rows="5" class="form-control w-100" name="SecondArticleDescription" id="SecondArticleDescription" placeholder="توضیح مقاله دوم را وارد کنید">@Model?.SecondArticleDescription</textarea>
                                 </div>
                                 <div class="form-group m-3 ">
                                     <div class="text-center">
@@ -109,8 +163,6 @@
                                     </div>
                                 </div>
                             </div>
-                            
-                            
                         </div>
                         <!-- /.card-body -->
 

--- a/Twelve/Areas/Admin/Views/Features/CreateItem.cshtml
+++ b/Twelve/Areas/Admin/Views/Features/CreateItem.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.FeatureItem
+@model ViewModels.FeatureItemCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -13,15 +13,55 @@
                     <!-- /.card-header -->
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
-                        <input type="hidden" name="FeatureID" value="@ViewBag.FeatureID" />
+                        <input type="hidden" name="FeatureId" value="@Model.FeatureId" />
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" id="Title" placeholder="عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="ShortDescription">توضیح کوتاه</label>
-                                <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="Title">عنوان</label>
+                                        <input type="text" name="Title" class="form-control" id="Title" value="@Model?.Title" placeholder="عنوان را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescription">توضیح کوتاه</label>
+                                        <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" value="@Model?.ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleEn">Title</label>
+                                        <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model?.TitleEn" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionEn">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionEn" id="ShortDescriptionEn" value="@Model?.ShortDescriptionEn" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleAr">Title</label>
+                                        <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model?.TitleAr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionAr">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionAr" id="ShortDescriptionAr" value="@Model?.ShortDescriptionAr" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleUr">Title</label>
+                                        <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model?.TitleUr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionUr">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionUr" id="ShortDescriptionUr" value="@Model?.ShortDescriptionUr" />
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">
@@ -39,7 +79,7 @@
 
                         <div class="card-footer">
                             <button type="submit" class="btn btn-success">ثبت</button>
-                            <a href="/Admin/Features/ShowItems/@ViewBag.FeatureID" class="btn btn-info float-left">بازگشت به لیست</a>
+                            <a href="/Admin/Features/ShowItems/@Model.FeatureId" class="btn btn-info float-left">بازگشت به لیست</a>
                         </div>
                     </form>
                 </div>

--- a/Twelve/Areas/Admin/Views/Features/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/Features/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.Feature
+@model ViewModels.FeatureCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -13,29 +13,83 @@
                     <!-- /.card-header -->
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
-                        @Html.HiddenFor(m => m.FeatureId)
-                        @Html.HiddenFor(m => m.ImageName)
-                        @Html.HiddenFor(m => m.AnimateFilename)
-                        @Html.HiddenFor(m => m.FirstArticleImage)
-                        @Html.HiddenFor(m => m.SecondArticleImage)
-                        @Html.HiddenFor(m => m.IntroduceImageName)
+                        <input type="hidden" name="FeatureId" value="@Model.FeatureId" />
+                        <input type="hidden" name="ImageName" value="@Model.ImageName" />
+                        <input type="hidden" name="AnimateFilename" value="@Model.AnimateFilename" />
+                        <input type="hidden" name="FirstArticleImage" value="@Model.FirstArticleImage" />
+                        <input type="hidden" name="SecondArticleImage" value="@Model.SecondArticleImage" />
+                        <input type="hidden" name="IntroduceImageName" value="@Model.IntroduceImageName" />
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" id="Title" value="@Model.Title" placeholder="عنوان را وارد کنید">
-                                @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
-                            </div>
-                            <div class="form-group">
-                                <label for="ShortDescription">توضیح کوتاه</label>
-                                <input type="text" class="form-control" name="ShortDescription" value="@Model.ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
-                                @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
-
-                            </div>
-                            <div class="form-group">
-                                <label for="FirstDescription">توضیح</label>
-                                <textarea rows="5" class="form-control w-100" name="FirstDescription" id="FirstDescription" placeholder="توضیح را وارد کنید">@Model.FirstDescription</textarea>
-                                @Html.ValidationMessageFor(model => model.FirstDescription, "", new { @class = "text-danger" })
-
+                            <div class="row">
+                                <div class="col-12">
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" name="Title" class="form-control" id="Title" value="@Model.Title" placeholder="عنوان را وارد کنید">
+                                                @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescription">توضیح کوتاه</label>
+                                                <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" value="@Model.ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                                                @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescription">توضیح</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescription" id="FirstDescription" placeholder="توضیح را وارد کنید">@Model.FirstDescription</textarea>
+                                                @Html.ValidationMessageFor(model => model.FirstDescription, "", new { @class = "text-danger" })
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionEn">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionEn" id="ShortDescriptionEn" value="@Model.ShortDescriptionEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionEn">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionEn" id="FirstDescriptionEn">@Model.FirstDescriptionEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionAr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionAr" id="ShortDescriptionAr" value="@Model.ShortDescriptionAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionAr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionAr" id="FirstDescriptionAr">@Model.FirstDescriptionAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionUr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionUr" id="ShortDescriptionUr" value="@Model.ShortDescriptionUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionUr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionUr" id="FirstDescriptionUr">@Model.FirstDescriptionUr</textarea>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">
@@ -81,7 +135,7 @@
                                 </div>
                                 <div class="form-group m-3 ">
                                     <div class="text-center">
-                                        <img id="imageFAPreview" class="thumbnail w-100 my-5" src="~/Images/Features/@Model.FirstArticleImage" />
+                                        <img id="imageFAPreview" class="thumbnail my-5 w-100" src="~/Images/Features/@Model.FirstArticleImage" />
                                     </div>
                                     <div class="form-group">
                                         <div class="col-md-10">
@@ -105,7 +159,7 @@
                                 </div>
                                 <div class="form-group m-3 ">
                                     <div class="text-center">
-                                        <img id="imageSAPreview" class="thumbnail w-100 my-5" src="~/Images/Features/@Model.SecondArticleImage" />
+                                        <img id="imageSAPreview" class="thumbnail my-5 w-100" src="~/Images/Features/@Model.SecondArticleImage" />
                                     </div>
                                     <div class="form-group">
                                         <div class="col-md-10">
@@ -115,11 +169,8 @@
                                     </div>
                                 </div>
                             </div>
-
-
                         </div>
                         <!-- /.card-body -->
-
                         <div class="card-footer">
                             <button type="submit" class="btn btn-warning">ثبت</button>
                             <a href="/Admin/Features" class="btn btn-info float-left">بازگشت به لیست</a>
@@ -131,12 +182,12 @@
         </div>
     </div><!-- /.container-fluid -->
 </div>
-@section Ckeditor {
-    <script>
-        $(function () {
-            $('#FirstDescription').ckeditor();
-        });
-    </script>
+@section Ckeditor{
+<script>
+    $(function () {
+        $('#FirstDescription').ckeditor();
+    });
+</script>
 }
 <script>
     imageProduct.onchange = evt => {

--- a/Twelve/Areas/Admin/Views/Features/UpdateItem.cshtml
+++ b/Twelve/Areas/Admin/Views/Features/UpdateItem.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.FeatureItem
+@model ViewModels.FeatureItemCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -13,17 +13,57 @@
                     <!-- /.card-header -->
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
-                        <input type="hidden" name="FeaturesItemId" id="FeaturesItemId" value="@Model.FeaturesItemId" />
-                        <input type="hidden" name="ImageName" id="ImageName" value="@Model.ImageName" />
-                        <input type="hidden" name="FeatureId" id="FeatureId" value="@Model.FeatureId" />
+                        <input type="hidden" name="FeaturesItemId" value="@Model.FeaturesItemId" />
+                        <input type="hidden" name="ImageName" value="@Model.ImageName" />
+                        <input type="hidden" name="FeatureId" value="@Model.FeatureId" />
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" value="@Model.Title" id="Title" placeholder="عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="ShortDescription">توضیح کوتاه</label>
-                                <input type="text" class="form-control" name="ShortDescription" value="@Model.ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="Title">عنوان</label>
+                                        <input type="text" name="Title" class="form-control" id="Title" value="@Model.Title" placeholder="عنوان را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescription">توضیح کوتاه</label>
+                                        <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" value="@Model.ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleEn">Title</label>
+                                        <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model.TitleEn" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionEn">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionEn" id="ShortDescriptionEn" value="@Model.ShortDescriptionEn" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleAr">Title</label>
+                                        <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model.TitleAr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionAr">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionAr" id="ShortDescriptionAr" value="@Model.ShortDescriptionAr" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleUr">Title</label>
+                                        <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model.TitleUr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionUr">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionUr" id="ShortDescriptionUr" value="@Model.ShortDescriptionUr" />
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">

--- a/ViewModels/BlogViewModels.cs
+++ b/ViewModels/BlogViewModels.cs
@@ -28,6 +28,15 @@ namespace ViewModels
         [Display(Name = "توضیحات")]
         [Required(ErrorMessage = "لطفا {0} را وارد کنید")]
         public string Description { get; set; }
+        public string TitleEn { get; set; }
+        public string TitleAr { get; set; }
+        public string TitleUr { get; set; }
+        public string ShortDescriptionEn { get; set; }
+        public string ShortDescriptionAr { get; set; }
+        public string ShortDescriptionUr { get; set; }
+        public string DescriptionEn { get; set; }
+        public string DescriptionAr { get; set; }
+        public string DescriptionUr { get; set; }
         public string ImageName { get; set; }
         public string Source { get; set; }
         public string Tags { get; set; }

--- a/ViewModels/FaqsViewModel.cs
+++ b/ViewModels/FaqsViewModel.cs
@@ -11,6 +11,12 @@ namespace ViewModels
         public int FaqID { get; set; }
         public string Question { get; set; }
         public string Answer { get; set; }
+        public string QuestionEn { get; set; }
+        public string QuestionAr { get; set; }
+        public string QuestionUr { get; set; }
+        public string AnswerEn { get; set; }
+        public string AnswerAr { get; set; }
+        public string AnswerUr { get; set; }
         public bool IsMain { get; set; }
         public List<FaqsGroupsItemViewModel> Groups { get; set; }
         public List<int> SelectedGroups { get; set; }

--- a/ViewModels/FeaturesViewModel.cs
+++ b/ViewModels/FeaturesViewModel.cs
@@ -53,4 +53,57 @@ namespace ViewModels
         public string Demo { get; set; }
         public bool IsBig { get; set; }
     }
+
+    public class FeatureCrudViewModel
+    {
+        public int FeatureId { get; set; }
+        public string Title { get; set; }
+        public string ShortDescription { get; set; }
+        public string FirstDescription { get; set; }
+        public string FirstArticleTitle { get; set; }
+        public string FirstArticleDescription { get; set; }
+        public string SecondArticleTitle { get; set; }
+        public string SecondArticleDescription { get; set; }
+        public string TitleEn { get; set; }
+        public string TitleAr { get; set; }
+        public string TitleUr { get; set; }
+        public string ShortDescriptionEn { get; set; }
+        public string ShortDescriptionAr { get; set; }
+        public string ShortDescriptionUr { get; set; }
+        public string FirstDescriptionEn { get; set; }
+        public string FirstDescriptionAr { get; set; }
+        public string FirstDescriptionUr { get; set; }
+        public string FirstArticleTitleEn { get; set; }
+        public string FirstArticleTitleAr { get; set; }
+        public string FirstArticleTitleUr { get; set; }
+        public string FirstArticleDescriptionEn { get; set; }
+        public string FirstArticleDescriptionAr { get; set; }
+        public string FirstArticleDescriptionUr { get; set; }
+        public string SecondArticleTitleEn { get; set; }
+        public string SecondArticleTitleAr { get; set; }
+        public string SecondArticleTitleUr { get; set; }
+        public string SecondArticleDescriptionEn { get; set; }
+        public string SecondArticleDescriptionAr { get; set; }
+        public string SecondArticleDescriptionUr { get; set; }
+        public string ImageName { get; set; }
+        public string AnimateFilename { get; set; }
+        public string FirstArticleImage { get; set; }
+        public string SecondArticleImage { get; set; }
+        public string IntroduceImageName { get; set; }
+    }
+
+    public class FeatureItemCrudViewModel
+    {
+        public int FeaturesItemId { get; set; }
+        public int FeatureId { get; set; }
+        public string Title { get; set; }
+        public string ShortDescription { get; set; }
+        public string TitleEn { get; set; }
+        public string TitleAr { get; set; }
+        public string TitleUr { get; set; }
+        public string ShortDescriptionEn { get; set; }
+        public string ShortDescriptionAr { get; set; }
+        public string ShortDescriptionUr { get; set; }
+        public string ImageName { get; set; }
+    }
 }


### PR DESCRIPTION
## Summary
- Extend feature view models with language-specific fields
- Persist feature and feature-item translations via repository methods and controller hooks
- Show FA/EN/AR/UR tabs on feature and feature-item create/update forms

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_688e95d3bfc48327bc0f6b96509ee7ca