### PR TITLE
Add multilingual support for blog, FAQ, and features editing

### DIFF
--- a/Services/Repository/IBlogGroupsRepository.cs
+++ b/Services/Repository/IBlogGroupsRepository.cs
@@ -15,6 +15,8 @@ namespace Services
         public bool Delete(BlogGroup blogGroup);
         public BlogGroup GetByID(int id);
         public List<BlogGroupNameViewModel> GetAllGroups();
+        public BlogGroupCrudViewModel GetForEdit(int id);
+        public void SaveTranslations(BlogGroupCrudViewModel group);
 
         public string GetBlogGroupNameByBlogID(int BlogID);
     }

--- a/Services/Repository/IBlogRepository.cs
+++ b/Services/Repository/IBlogRepository.cs
@@ -46,6 +46,7 @@ namespace Services
         public bool Delete(int ID);
         public BlogCrudViewModel GetModelForCreate();
         public BlogCrudViewModel GetByID(int BlogID);
+        public void SaveTranslations(BlogCrudViewModel blog);
         public BlogCommentsPageDataViewModel GetNewsComments(string q = "", int PageID = 1);
         public BlogCommentsPageDataViewModel GetNewsConfirmComments(string q = "", int PageID = 1);
         public BlogCommentsPageDataViewModel GetNewsAnswerComments(string q = "", int PageID = 1);

--- a/Services/Repository/IFaqsRepository.cs
+++ b/Services/Repository/IFaqsRepository.cs
@@ -11,18 +11,22 @@ namespace Services
     public interface IFaqsRepository : IDisposable
     {
         public FaqContent GetFaqContent();
-        public bool UpdateFaqContent(FaqContent content);
+        public FaqContentCrudViewModel GetFaqContentForEdit();
+        public bool UpdateFaqContent(FaqContentCrudViewModel content);
         public bool CreateGroup(FaqGroup faqGroup);
         public bool UpdateGroup(FaqGroup faqGroup);
         public bool DeleteGroup(FaqGroup faqGroup);
 
         public FaqGroup GetGroupByID(int id);
+        public FaqGroupCrudViewModel GetGroupForEdit(int id);
+        public void SaveGroupTranslations(FaqGroupCrudViewModel group);
 
         public FaqsCrudViewModel GetModelForCreate();
         public FaqsCrudViewModel GetByID(int FaqID);
         public bool Create(FaqsCrudViewModel faqs);
         public bool Update(FaqsCrudViewModel faqs);
         public bool Delete(int FaqID);
+        public void SaveTranslations(FaqsCrudViewModel faqs);
 
         public PaginationViewModel GetPagination(double PageCount, int PageID = 1);
 

--- a/Services/Repository/IFeaturesRepository.cs
+++ b/Services/Repository/IFeaturesRepository.cs
@@ -12,16 +12,19 @@ namespace Services
     public interface IFeaturesRepository : IDisposable
     {
         public FeaturesContent GetFeaturesContent();
-        public bool UpdateFeaturesContent(FeaturesContent content);
+        public FeaturesContentCrudViewModel GetFeaturesContentForEdit();
+        public bool UpdateFeaturesContent(FeaturesContentCrudViewModel content);
 
         public IntroduceAppViewModel GetIntroduceApp();
         public List<BlogItemViewModel> GetRelatedNews(int FeatureID);
 
         public Feature GetByID(int id);
+        public FeatureCrudViewModel GetForEdit(int id);
         public bool Create(Feature feature , IFormFile ImageName , IFormFile AnimateFile , IFormFile FirstArticleImage , IFormFile SecondArticleImage, IFormFile IntroduceImage);
         public bool Update(Feature feature , IFormFile ImageName , IFormFile AnimateFile , IFormFile FirstArticleImage , IFormFile SecondArticleImage , IFormFile IntroduceImage);
         public bool Update(Feature feature , IFormFile IntroduceImage);
         public bool Delete(Feature feature);
+        public void SaveTranslations(FeatureCrudViewModel feature);
         public AdminFeaturesPageDataViewModel GetAdminFeatures(string q = "" , int PageID =1);
         public PaginationViewModel GetPagination(double PageCount, int PageID = 1);
 
@@ -31,9 +34,11 @@ namespace Services
         public List<Feature> GetFeatureIntroduces();
 
         public FeatureItem GetItemByID(int ItemID);
+        public FeatureItemCrudViewModel GetItemForEdit(int ItemID);
         public bool CreateItem(FeatureItem featureItem , IFormFile formFile);
         public bool UpdateItem(FeatureItem featureItem , IFormFile formFile);
         public bool DeleteItem(FeatureItem featureItem);
+        public void SaveItemTranslations(FeatureItemCrudViewModel item);
 
         public List<FeatureIconsViewModel> GetFeaturesIcons(int featureID);
     }

--- a/Services/Repository/ISiteRepository.cs
+++ b/Services/Repository/ISiteRepository.cs
@@ -12,11 +12,11 @@ namespace Services
     public interface ISiteRepository : IDisposable
     {
         #region Contents
-        public IndexContent GetIndexContent();
-        public ContactUsContent GetContactUsContent();
-        public bool UpdateIndexContent(IndexContent content);
+        public IndexContentCrudViewModel GetIndexContent();
+        public ContactUsContentCrudViewModel GetContactUsContent();
+        public bool UpdateIndexContent(IndexContentCrudViewModel content);
         public bool UpdateAboutUsContent(AboutUsContent content , IFormFile imageProduct , IFormFile downloadProduct);
-        public bool UpdateContactUsContent(ContactUsContent content);
+        public bool UpdateContactUsContent(ContactUsContentCrudViewModel content);
 
         #endregion Contents
         public ContentItemViewModel GetContactUsSecondDescription();

--- a/Services/Services/BlogGroupsRepository.cs
+++ b/Services/Services/BlogGroupsRepository.cs
@@ -63,6 +63,30 @@ namespace Services
             return groups;
         }
 
+        public BlogGroupCrudViewModel GetForEdit(int id)
+        {
+            var group = db.BlogGroups.Find(id);
+            var translations = db.EntityTranslations
+                .Where(t => t.EntityName == nameof(BlogGroup) && t.EntityId == id)
+                .ToList();
+            return new BlogGroupCrudViewModel
+            {
+                BlogGroupId = group.BlogGroupId,
+                GroupName = group.GroupName,
+                ParentId = group.ParentId,
+                GroupNameEn = translations.FirstOrDefault(t => t.Property == "GroupName" && t.Culture == "en")?.Value,
+                GroupNameAr = translations.FirstOrDefault(t => t.Property == "GroupName" && t.Culture == "ar")?.Value,
+                GroupNameUr = translations.FirstOrDefault(t => t.Property == "GroupName" && t.Culture == "ur")?.Value
+            };
+        }
+
+        public void SaveTranslations(BlogGroupCrudViewModel group)
+        {
+            SaveTranslation(nameof(BlogGroup), group.BlogGroupId, "GroupName", "en", group.GroupNameEn);
+            SaveTranslation(nameof(BlogGroup), group.BlogGroupId, "GroupName", "ar", group.GroupNameAr);
+            SaveTranslation(nameof(BlogGroup), group.BlogGroupId, "GroupName", "ur", group.GroupNameUr);
+        }
+
 
         public string GetBlogGroupNameByBlogID(int BlogID)
         {
@@ -91,6 +115,25 @@ namespace Services
             {
                 return false;
             }
+        }
+
+        private void SaveTranslation(string entityName, int entityId, string property, string culture, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return;
+            var tr = db.EntityTranslations.FirstOrDefault(t => t.EntityName == entityName && t.EntityId == entityId && t.Property == property && t.Culture == culture);
+            if (tr == null)
+            {
+                tr = new EntityTranslation
+                {
+                    EntityName = entityName,
+                    EntityId = entityId,
+                    Property = property,
+                    Culture = culture
+                };
+                db.EntityTranslations.Add(tr);
+            }
+            tr.Value = value;
+            db.SaveChanges();
         }
     }
 }

--- a/Services/Services/BlogRepository.cs
+++ b/Services/Services/BlogRepository.cs
@@ -628,14 +628,16 @@ namespace Services
                 var posts = db.Blogs.OrderByDescending(b => b.CreateDate).Skip(skip).Take(take).ToList();
                 foreach (var item in posts)
                 {
-                    List<string> groupName = db.SelectedBlogGroups.Where(b => b.BlogId == item.BlogId).Include(b => b.BlogGroup).Select(b => b.BlogGroup.GroupName).ToList();
+                    var tr = db.BlogTranslations.FirstOrDefault(t => t.BlogId == item.BlogId && t.Language == CurrentCulture);
+                    var groups = db.SelectedBlogGroups.Where(b => b.BlogId == item.BlogId).Include(b => b.BlogGroup).ToList();
+                    groups.ForEach(g => g.BlogGroup.ApplyTranslation(db));
                     blogPosts.Posts.Add(new BlogPostsItemViewModel()
                     {
                         BlogID = item.BlogId,
-                        Title = item.Title,
+                        Title = tr?.Title ?? item.Title,
                         CreateDate = DateConvertor.ToShamsi(item.CreateDate),
                         View = item.PostView,
-                        GroupName = string.Join(" ، ", groupName)
+                        GroupName = string.Join(" ، ", groups.Select(g => g.BlogGroup.GroupName))
                     });
                 }
                 double pCount = Convert.ToDouble(Convert.ToDouble(db.Blogs.ToList().Count()) / Convert.ToDouble(take));
@@ -648,14 +650,16 @@ namespace Services
                 var posts = db.Blogs.Where(b => b.Title.Contains(q)).OrderByDescending(b => b.CreateDate).Skip(skip).Take(take).ToList();
                 foreach (var item in posts)
                 {
-                    List<string> groupName = db.SelectedBlogGroups.Where(b => b.BlogId == item.BlogId).Include(b => b.BlogGroup).Select(b => b.BlogGroup.GroupName).ToList();
+                    var tr = db.BlogTranslations.FirstOrDefault(t => t.BlogId == item.BlogId && t.Language == CurrentCulture);
+                    var groups = db.SelectedBlogGroups.Where(b => b.BlogId == item.BlogId).Include(b => b.BlogGroup).ToList();
+                    groups.ForEach(g => g.BlogGroup.ApplyTranslation(db));
                     blogPosts.Posts.Add(new BlogPostsItemViewModel()
                     {
                         BlogID = item.BlogId,
-                        Title = item.Title,
+                        Title = tr?.Title ?? item.Title,
                         CreateDate = DateConvertor.ToShamsi(item.CreateDate),
                         View = item.PostView,
-                        GroupName = string.Join(" ، ", groupName)
+                        GroupName = string.Join(" ، ", groups.Select(g => g.BlogGroup.GroupName))
                     });
                 }
                 double pCount = Convert.ToDouble(Convert.ToDouble(db.Blogs.Where(b => b.Title.Contains(q)).ToList().Count()) / Convert.ToDouble(take));
@@ -1053,6 +1057,7 @@ namespace Services
                 };
                 db.Blogs.Add(model);
                 db.SaveChanges();
+                blog.BlogID = model.BlogId;
 
                 var tags = blog.Tags.Split('،').ToList();
 
@@ -1171,6 +1176,7 @@ namespace Services
             BlogCrudViewModel model = new BlogCrudViewModel();
             model.Groups = new List<BlogGroupNameViewModel>();
             var items = db.BlogGroups.ToList();
+            items.ApplyTranslations(db);
             foreach (var item in items)
             {
                 model.Groups.Add(new BlogGroupNameViewModel()
@@ -1199,7 +1205,30 @@ namespace Services
                 SelectedGroups = db.SelectedBlogGroups.Where(s => s.BlogId == BlogID).Select(s => s.BlogGroupId).ToList()
             };
 
+            var trEn = db.BlogTranslations.FirstOrDefault(t => t.BlogId == BlogID && t.Language == "en");
+            var trAr = db.BlogTranslations.FirstOrDefault(t => t.BlogId == BlogID && t.Language == "ar");
+            var trUr = db.BlogTranslations.FirstOrDefault(t => t.BlogId == BlogID && t.Language == "ur");
+            if (trEn != null)
+            {
+                model.TitleEn = trEn.Title;
+                model.ShortDescriptionEn = trEn.ShortDescription;
+                model.DescriptionEn = trEn.Description;
+            }
+            if (trAr != null)
+            {
+                model.TitleAr = trAr.Title;
+                model.ShortDescriptionAr = trAr.ShortDescription;
+                model.DescriptionAr = trAr.Description;
+            }
+            if (trUr != null)
+            {
+                model.TitleUr = trUr.Title;
+                model.ShortDescriptionUr = trUr.ShortDescription;
+                model.DescriptionUr = trUr.Description;
+            }
+
             var groups = db.BlogGroups.ToList();
+            groups.ApplyTranslations(db);
             model.Groups = new List<BlogGroupNameViewModel>();
             foreach (var item in groups)
             {
@@ -1210,6 +1239,31 @@ namespace Services
                 });
             }
             return model;
+        }
+
+        public void SaveTranslations(BlogCrudViewModel blog)
+        {
+            SaveBlogTranslation(blog.BlogID, "en", blog.TitleEn, blog.ShortDescriptionEn, blog.DescriptionEn);
+            SaveBlogTranslation(blog.BlogID, "ar", blog.TitleAr, blog.ShortDescriptionAr, blog.DescriptionAr);
+            SaveBlogTranslation(blog.BlogID, "ur", blog.TitleUr, blog.ShortDescriptionUr, blog.DescriptionUr);
+        }
+
+        private void SaveBlogTranslation(int blogId, string lang, string title, string shortDescription, string description)
+        {
+            if (string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(shortDescription) && string.IsNullOrWhiteSpace(description))
+            {
+                return;
+            }
+            var tr = db.BlogTranslations.FirstOrDefault(t => t.BlogId == blogId && t.Language == lang);
+            if (tr == null)
+            {
+                tr = new BlogTranslation { BlogId = blogId, Language = lang };
+                db.BlogTranslations.Add(tr);
+            }
+            tr.Title = title ?? "";
+            tr.ShortDescription = shortDescription ?? "";
+            tr.Description = description ?? "";
+            db.SaveChanges();
         }
 
         #region NewsCrud

--- a/Services/Services/FaqsRepository.cs
+++ b/Services/Services/FaqsRepository.cs
@@ -21,17 +21,20 @@ namespace Services
 
         public string GetFaqGroupNameByID(int GroupID)
         {
-            return db.FaqGroups.Find(GroupID).GroupName;
+            var item = db.FaqGroups.Find(GroupID);
+            item.ApplyTranslation(db);
+            return item.GroupName;
         }
 
         public List<FaqsGroupsItemViewModel> GetFaqGroups()
         {
             var items = db.FaqGroups.ToList();
+            items.ApplyTranslations(db);
             List<FaqsGroupsItemViewModel> model = new List<FaqsGroupsItemViewModel>();
 
             foreach (var item in items)
             {
-                model.Add(new FaqsGroupsItemViewModel 
+                model.Add(new FaqsGroupsItemViewModel
                 {
                     GroupID = item.FaqGroupId,
                     GroupName = item.GroupName
@@ -165,6 +168,24 @@ namespace Services
                 Question = faq.Question,
                 IsMain = faq.IsMain
             };
+            var trEn = db.FaqTranslations.FirstOrDefault(t => t.FaqId == FaqID && t.Language == "en");
+            var trAr = db.FaqTranslations.FirstOrDefault(t => t.FaqId == FaqID && t.Language == "ar");
+            var trUr = db.FaqTranslations.FirstOrDefault(t => t.FaqId == FaqID && t.Language == "ur");
+            if (trEn != null)
+            {
+                model.QuestionEn = trEn.Question;
+                model.AnswerEn = trEn.Answer;
+            }
+            if (trAr != null)
+            {
+                model.QuestionAr = trAr.Question;
+                model.AnswerAr = trAr.Answer;
+            }
+            if (trUr != null)
+            {
+                model.QuestionUr = trUr.Question;
+                model.AnswerUr = trUr.Answer;
+            }
             var groups = db.FaqGroups.ToList();
             model.Groups = new List<FaqsGroupsItemViewModel>();
             foreach (var group in groups)
@@ -178,6 +199,30 @@ namespace Services
             var selectedGroups = db.SelectedFaqGroups.Where(f => f.FaqId == FaqID).Select(f => f.FaqGroupId).ToList();
             model.SelectedGroups = selectedGroups;
             return model;
+        }
+
+        public void SaveTranslations(FaqsCrudViewModel faqs)
+        {
+            SaveFaqTranslation(faqs.FaqID, "en", faqs.QuestionEn, faqs.AnswerEn);
+            SaveFaqTranslation(faqs.FaqID, "ar", faqs.QuestionAr, faqs.AnswerAr);
+            SaveFaqTranslation(faqs.FaqID, "ur", faqs.QuestionUr, faqs.AnswerUr);
+        }
+
+        private void SaveFaqTranslation(int faqId, string lang, string question, string answer)
+        {
+            if (string.IsNullOrWhiteSpace(question) && string.IsNullOrWhiteSpace(answer))
+            {
+                return;
+            }
+            var tr = db.FaqTranslations.FirstOrDefault(t => t.FaqId == faqId && t.Language == lang);
+            if (tr == null)
+            {
+                tr = new FaqTranslation { FaqId = faqId, Language = lang };
+                db.FaqTranslations.Add(tr);
+            }
+            tr.Question = question ?? "";
+            tr.Answer = answer ?? "";
+            db.SaveChanges();
         }
 
         public bool Create(FaqsCrudViewModel faqs)
@@ -196,6 +241,7 @@ namespace Services
                 };
                 db.Faqs.Add(faq);
                 db.SaveChanges();
+                faqs.FaqID = faq.FaqId;
                 foreach (var item in faqs.SelectedGroups)
                 {
                     var selected = new SelectedFaqGroup() { FaqId = faq.FaqId , FaqGroupId = item };
@@ -329,23 +375,101 @@ namespace Services
             return db.FaqGroups.Find(id);
         }
 
-        public FaqContent GetFaqContent()
+        public FaqGroupCrudViewModel GetGroupForEdit(int id)
         {
-            return db.FaqContents.FirstOrDefault();
+            var group = db.FaqGroups.Find(id);
+            var translations = db.EntityTranslations.Where(t => t.EntityName == nameof(FaqGroup) && t.EntityId == id).ToList();
+            return new FaqGroupCrudViewModel
+            {
+                FaqGroupId = group.FaqGroupId,
+                GroupName = group.GroupName,
+                ParentId = group.ParentId,
+                GroupNameEn = translations.FirstOrDefault(t => t.Property == nameof(FaqGroup.GroupName) && t.Culture == "en")?.Value,
+                GroupNameAr = translations.FirstOrDefault(t => t.Property == nameof(FaqGroup.GroupName) && t.Culture == "ar")?.Value,
+                GroupNameUr = translations.FirstOrDefault(t => t.Property == nameof(FaqGroup.GroupName) && t.Culture == "ur")?.Value
+            };
         }
 
-        public bool UpdateFaqContent(FaqContent content )
+        public FaqContent GetFaqContent()
+        {
+            var item = db.FaqContents.FirstOrDefault();
+            item.ApplyTranslation(db);
+            return item;
+        }
+
+        public FaqContentCrudViewModel GetFaqContentForEdit()
+        {
+            var item = db.FaqContents.FirstOrDefault();
+            var translations = db.EntityTranslations.Where(t => t.EntityName == nameof(FaqContent) && t.EntityId == item.FaqContentId).ToList();
+            return new FaqContentCrudViewModel
+            {
+                FaqContentId = item.FaqContentId,
+                FaqContentTitle = item.FaqContentTitle,
+                FaqContentSubTitle = item.FaqContentSubTitle,
+                FaqContentDescription = item.FaqContentDescription,
+                FaqContentTitleEn = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentTitle) && t.Culture == "en")?.Value,
+                FaqContentTitleAr = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentTitle) && t.Culture == "ar")?.Value,
+                FaqContentTitleUr = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentTitle) && t.Culture == "ur")?.Value,
+                FaqContentSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentSubTitle) && t.Culture == "en")?.Value,
+                FaqContentSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentSubTitle) && t.Culture == "ar")?.Value,
+                FaqContentSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentSubTitle) && t.Culture == "ur")?.Value,
+                FaqContentDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentDescription) && t.Culture == "en")?.Value,
+                FaqContentDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentDescription) && t.Culture == "ar")?.Value,
+                FaqContentDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentDescription) && t.Culture == "ur")?.Value
+            };
+        }
+
+        public bool UpdateFaqContent(FaqContentCrudViewModel content)
         {
             try
             {
-                db.FaqContents.Update(content);
+                var entity = db.FaqContents.Find(content.FaqContentId);
+                entity.FaqContentTitle = content.FaqContentTitle;
+                entity.FaqContentSubTitle = content.FaqContentSubTitle;
+                entity.FaqContentDescription = content.FaqContentDescription;
+                db.FaqContents.Update(entity);
                 db.SaveChanges();
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentTitle), "en", content.FaqContentTitleEn);
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentTitle), "ar", content.FaqContentTitleAr);
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentTitle), "ur", content.FaqContentTitleUr);
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentSubTitle), "en", content.FaqContentSubTitleEn);
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentSubTitle), "ar", content.FaqContentSubTitleAr);
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentSubTitle), "ur", content.FaqContentSubTitleUr);
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentDescription), "en", content.FaqContentDescriptionEn);
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentDescription), "ar", content.FaqContentDescriptionAr);
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentDescription), "ur", content.FaqContentDescriptionUr);
                 return true;
             }
-            catch 
+            catch
             {
                 return false;
             }
+        }
+
+        public void SaveGroupTranslations(FaqGroupCrudViewModel group)
+        {
+            SaveTranslation(nameof(FaqGroup), group.FaqGroupId, nameof(FaqGroup.GroupName), "en", group.GroupNameEn);
+            SaveTranslation(nameof(FaqGroup), group.FaqGroupId, nameof(FaqGroup.GroupName), "ar", group.GroupNameAr);
+            SaveTranslation(nameof(FaqGroup), group.FaqGroupId, nameof(FaqGroup.GroupName), "ur", group.GroupNameUr);
+        }
+
+        private void SaveTranslation(string entityName, int entityId, string property, string culture, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return;
+            var tr = db.EntityTranslations.FirstOrDefault(t => t.EntityName == entityName && t.EntityId == entityId && t.Property == property && t.Culture == culture);
+            if (tr == null)
+            {
+                tr = new EntityTranslation
+                {
+                    EntityName = entityName,
+                    EntityId = entityId,
+                    Property = property,
+                    Culture = culture
+                };
+                db.EntityTranslations.Add(tr);
+            }
+            tr.Value = value;
+            db.SaveChanges();
         }
     }
 }

--- a/Services/Services/FeaturesRepository.cs
+++ b/Services/Services/FeaturesRepository.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -180,6 +181,27 @@ namespace Services
             return item;
         }
 
+        public FeatureItemCrudViewModel GetItemForEdit(int ItemID)
+        {
+            var item = db.FeatureItems.Find(ItemID);
+            var model = new FeatureItemCrudViewModel
+            {
+                FeaturesItemId = item.FeaturesItemId,
+                FeatureId = item.FeatureId,
+                Title = item.Title,
+                ShortDescription = item.ShortDescription,
+                ImageName = item.ImageName
+            };
+            var tr = db.EntityTranslations.ToList();
+            model.TitleEn = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "Title" && t.Culture == "en")?.Value;
+            model.TitleAr = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "Title" && t.Culture == "ar")?.Value;
+            model.TitleUr = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "Title" && t.Culture == "ur")?.Value;
+            model.ShortDescriptionEn = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "ShortDescription" && t.Culture == "en")?.Value;
+            model.ShortDescriptionAr = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "ShortDescription" && t.Culture == "ar")?.Value;
+            model.ShortDescriptionUr = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "ShortDescription" && t.Culture == "ur")?.Value;
+            return model;
+        }
+
         public bool CreateItem(FeatureItem featureItem, IFormFile ImageName)
         {
             try
@@ -252,6 +274,16 @@ namespace Services
             }
         }
 
+        public void SaveItemTranslations(FeatureItemCrudViewModel item)
+        {
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "Title", "en", item.TitleEn);
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "Title", "ar", item.TitleAr);
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "Title", "ur", item.TitleUr);
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "ShortDescription", "en", item.ShortDescriptionEn);
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "ShortDescription", "ar", item.ShortDescriptionAr);
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "ShortDescription", "ur", item.ShortDescriptionUr);
+        }
+
         public bool Create(Feature feature, IFormFile ImageName, IFormFile AnimateFile, IFormFile FirstArticleImage, IFormFile SecondArticleImage ,  IFormFile IntroduceImage)
         {
             try
@@ -309,6 +341,50 @@ namespace Services
         public Feature GetByID(int id)
         {
             return db.Features.Find(id);
+        }
+
+        public FeatureCrudViewModel GetForEdit(int id)
+        {
+            var feature = db.Features.Find(id);
+            var model = new FeatureCrudViewModel
+            {
+                FeatureId = feature.FeatureId,
+                Title = feature.Title,
+                ShortDescription = feature.ShortDescription,
+                FirstDescription = feature.FirstDescription,
+                FirstArticleTitle = feature.FirstArticleTitle,
+                FirstArticleDescription = feature.FirstArticleDescription,
+                SecondArticleTitle = feature.SecondArticleTitle,
+                SecondArticleDescription = feature.SecondArticleDescription,
+                ImageName = feature.ImageName,
+                AnimateFilename = feature.AnimateFilename,
+                FirstArticleImage = feature.FirstArticleImage,
+                SecondArticleImage = feature.SecondArticleImage,
+                IntroduceImageName = feature.IntroduceImageName
+            };
+            var tr = db.EntityTranslations.ToList();
+            model.TitleEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "Title" && t.Culture == "en")?.Value;
+            model.TitleAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "Title" && t.Culture == "ar")?.Value;
+            model.TitleUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "Title" && t.Culture == "ur")?.Value;
+            model.ShortDescriptionEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "ShortDescription" && t.Culture == "en")?.Value;
+            model.ShortDescriptionAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "ShortDescription" && t.Culture == "ar")?.Value;
+            model.ShortDescriptionUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "ShortDescription" && t.Culture == "ur")?.Value;
+            model.FirstDescriptionEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstDescription" && t.Culture == "en")?.Value;
+            model.FirstDescriptionAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstDescription" && t.Culture == "ar")?.Value;
+            model.FirstDescriptionUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstDescription" && t.Culture == "ur")?.Value;
+            model.FirstArticleTitleEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleTitle" && t.Culture == "en")?.Value;
+            model.FirstArticleTitleAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleTitle" && t.Culture == "ar")?.Value;
+            model.FirstArticleTitleUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleTitle" && t.Culture == "ur")?.Value;
+            model.FirstArticleDescriptionEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleDescription" && t.Culture == "en")?.Value;
+            model.FirstArticleDescriptionAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleDescription" && t.Culture == "ar")?.Value;
+            model.FirstArticleDescriptionUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleDescription" && t.Culture == "ur")?.Value;
+            model.SecondArticleTitleEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleTitle" && t.Culture == "en")?.Value;
+            model.SecondArticleTitleAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleTitle" && t.Culture == "ar")?.Value;
+            model.SecondArticleTitleUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleTitle" && t.Culture == "ur")?.Value;
+            model.SecondArticleDescriptionEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleDescription" && t.Culture == "en")?.Value;
+            model.SecondArticleDescriptionAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleDescription" && t.Culture == "ar")?.Value;
+            model.SecondArticleDescriptionUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleDescription" && t.Culture == "ur")?.Value;
+            return model;
         }
 
         public bool Update(Feature feature, IFormFile ImageName, IFormFile AnimateFile, IFormFile FirstArticleImage, IFormFile SecondArticleImage, IFormFile IntroduceImage)
@@ -426,6 +502,31 @@ namespace Services
             }
         }
 
+        public void SaveTranslations(FeatureCrudViewModel feature)
+        {
+            SaveTranslation("Feature", feature.FeatureId, "Title", "en", feature.TitleEn);
+            SaveTranslation("Feature", feature.FeatureId, "Title", "ar", feature.TitleAr);
+            SaveTranslation("Feature", feature.FeatureId, "Title", "ur", feature.TitleUr);
+            SaveTranslation("Feature", feature.FeatureId, "ShortDescription", "en", feature.ShortDescriptionEn);
+            SaveTranslation("Feature", feature.FeatureId, "ShortDescription", "ar", feature.ShortDescriptionAr);
+            SaveTranslation("Feature", feature.FeatureId, "ShortDescription", "ur", feature.ShortDescriptionUr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstDescription", "en", feature.FirstDescriptionEn);
+            SaveTranslation("Feature", feature.FeatureId, "FirstDescription", "ar", feature.FirstDescriptionAr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstDescription", "ur", feature.FirstDescriptionUr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleTitle", "en", feature.FirstArticleTitleEn);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleTitle", "ar", feature.FirstArticleTitleAr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleTitle", "ur", feature.FirstArticleTitleUr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleDescription", "en", feature.FirstArticleDescriptionEn);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleDescription", "ar", feature.FirstArticleDescriptionAr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleDescription", "ur", feature.FirstArticleDescriptionUr);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleTitle", "en", feature.SecondArticleTitleEn);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleTitle", "ar", feature.SecondArticleTitleAr);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleTitle", "ur", feature.SecondArticleTitleUr);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleDescription", "en", feature.SecondArticleDescriptionEn);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleDescription", "ar", feature.SecondArticleDescriptionAr);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleDescription", "ur", feature.SecondArticleDescriptionUr);
+        }
+
         public bool Delete(Feature feature)
         {
             try
@@ -521,18 +622,55 @@ namespace Services
 
         public FeaturesContent GetFeaturesContent()
         {
-            return db.FeaturesContents.FirstOrDefault();
+            var item = db.FeaturesContents.FirstOrDefault();
+            item.ApplyTranslation(db);
+            return item;
         }
 
-        public bool UpdateFeaturesContent(FeaturesContent content)
+        public FeaturesContentCrudViewModel GetFeaturesContentForEdit()
+        {
+            var item = db.FeaturesContents.FirstOrDefault();
+            var translations = db.EntityTranslations.Where(t => t.EntityName == nameof(FeaturesContent) && t.EntityId == item.FeatureContentId).ToList();
+            return new FeaturesContentCrudViewModel
+            {
+                FeatureContentId = item.FeatureContentId,
+                FeaturesTitle = item.FeaturesTitle,
+                FeatruesSubTitle = item.FeatruesSubTitle,
+                FeaturesDescription = item.FeaturesDescription,
+                FeaturesTitleEn = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeaturesTitle) && t.Culture == "en")?.Value,
+                FeaturesTitleAr = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeaturesTitle) && t.Culture == "ar")?.Value,
+                FeaturesTitleUr = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeaturesTitle) && t.Culture == "ur")?.Value,
+                FeatruesSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeatruesSubTitle) && t.Culture == "en")?.Value,
+                FeatruesSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeatruesSubTitle) && t.Culture == "ar")?.Value,
+                FeatruesSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeatruesSubTitle) && t.Culture == "ur")?.Value,
+                FeaturesDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeaturesDescription) && t.Culture == "en")?.Value,
+                FeaturesDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeaturesDescription) && t.Culture == "ar")?.Value,
+                FeaturesDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeaturesDescription) && t.Culture == "ur")?.Value
+            };
+        }
+
+        public bool UpdateFeaturesContent(FeaturesContentCrudViewModel content)
         {
             try
             {
-                db.FeaturesContents.Update(content);
+                var entity = db.FeaturesContents.Find(content.FeatureContentId);
+                entity.FeaturesTitle = content.FeaturesTitle;
+                entity.FeatruesSubTitle = content.FeatruesSubTitle;
+                entity.FeaturesDescription = content.FeaturesDescription;
+                db.FeaturesContents.Update(entity);
                 db.SaveChanges();
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeaturesTitle), "en", content.FeaturesTitleEn);
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeaturesTitle), "ar", content.FeaturesTitleAr);
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeaturesTitle), "ur", content.FeaturesTitleUr);
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeatruesSubTitle), "en", content.FeatruesSubTitleEn);
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeatruesSubTitle), "ar", content.FeatruesSubTitleAr);
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeatruesSubTitle), "ur", content.FeatruesSubTitleUr);
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeaturesDescription), "en", content.FeaturesDescriptionEn);
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeaturesDescription), "ar", content.FeaturesDescriptionAr);
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeaturesDescription), "ur", content.FeaturesDescriptionUr);
                 return true;
             }
-            catch 
+            catch
             {
                 return false;
             }
@@ -543,6 +681,28 @@ namespace Services
             return db.Features.ToList();
         }
 
-        
+        private void SaveTranslation(string entityName, int entityId, string property, string culture, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return;
+            }
+            var tr = db.EntityTranslations.FirstOrDefault(t => t.EntityName == entityName && t.EntityId == entityId && t.Property == property && t.Culture == culture);
+            if (tr == null)
+            {
+                tr = new EntityTranslation
+                {
+                    EntityName = entityName,
+                    EntityId = entityId,
+                    Property = property,
+                    Culture = culture
+                };
+                db.EntityTranslations.Add(tr);
+            }
+            tr.Value = value;
+            db.SaveChanges();
+        }
+
+
     }
 }

--- a/Services/Services/LocalizationExtensions.cs
+++ b/Services/Services/LocalizationExtensions.cs
@@ -15,6 +15,10 @@ namespace Services
             var culture = CultureInfo.CurrentUICulture.Name;
             var entityName = typeof(T).Name;
             var idProp = typeof(T).GetProperties().FirstOrDefault(p => p.Name == entityName + "Id");
+            if (idProp == null)
+            {
+                idProp = typeof(T).GetProperties().FirstOrDefault(p => p.Name.EndsWith("Id", StringComparison.OrdinalIgnoreCase) && p.PropertyType == typeof(int));
+            }
             if (idProp == null) return;
             var id = (int)(idProp.GetValue(entity) ?? 0);
             var translations = db.EntityTranslations

--- a/Services/Services/SiteRepository.cs
+++ b/Services/Services/SiteRepository.cs
@@ -652,19 +652,95 @@ namespace Services
         }
 
         #region Contents
-        public IndexContent GetIndexContent()
+        public IndexContentCrudViewModel GetIndexContent()
         {
             var item = db.IndexContents.FirstOrDefault();
-            item.ApplyTranslation(db);
-            return item;
+            var translations = db.EntityTranslations.Where(t => t.EntityName == nameof(IndexContent) && t.EntityId == item.IndexContentId).ToList();
+            return new IndexContentCrudViewModel
+            {
+                IndexContentId = item.IndexContentId,
+                AboutTitle = item.AboutTitle,
+                AboutSubTitle = item.AboutSubTitle,
+                AboutDescription = item.AboutDescription,
+                FeatureTitle = item.FeatureTitle,
+                FeatureSubTitle = item.FeatureSubTitle,
+                FeatureDescription = item.FeatureDescription,
+                FaqTitle = item.FaqTitle,
+                FaqSubTitle = item.FaqSubTitle,
+                FaqDescription = item.FaqDescription,
+                AboutTitleEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutTitle) && t.Culture == "en")?.Value,
+                AboutTitleAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutTitle) && t.Culture == "ar")?.Value,
+                AboutTitleUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutTitle) && t.Culture == "ur")?.Value,
+                AboutSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutSubTitle) && t.Culture == "en")?.Value,
+                AboutSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutSubTitle) && t.Culture == "ar")?.Value,
+                AboutSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutSubTitle) && t.Culture == "ur")?.Value,
+                AboutDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutDescription) && t.Culture == "en")?.Value,
+                AboutDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutDescription) && t.Culture == "ar")?.Value,
+                AboutDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutDescription) && t.Culture == "ur")?.Value,
+                FeatureTitleEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureTitle) && t.Culture == "en")?.Value,
+                FeatureTitleAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureTitle) && t.Culture == "ar")?.Value,
+                FeatureTitleUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureTitle) && t.Culture == "ur")?.Value,
+                FeatureSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureSubTitle) && t.Culture == "en")?.Value,
+                FeatureSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureSubTitle) && t.Culture == "ar")?.Value,
+                FeatureSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureSubTitle) && t.Culture == "ur")?.Value,
+                FeatureDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureDescription) && t.Culture == "en")?.Value,
+                FeatureDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureDescription) && t.Culture == "ar")?.Value,
+                FeatureDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureDescription) && t.Culture == "ur")?.Value,
+                FaqTitleEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqTitle) && t.Culture == "en")?.Value,
+                FaqTitleAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqTitle) && t.Culture == "ar")?.Value,
+                FaqTitleUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqTitle) && t.Culture == "ur")?.Value,
+                FaqSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqSubTitle) && t.Culture == "en")?.Value,
+                FaqSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqSubTitle) && t.Culture == "ar")?.Value,
+                FaqSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqSubTitle) && t.Culture == "ur")?.Value,
+                FaqDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqDescription) && t.Culture == "en")?.Value,
+                FaqDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqDescription) && t.Culture == "ar")?.Value,
+                FaqDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqDescription) && t.Culture == "ur")?.Value
+            };
         }
 
-        public bool UpdateIndexContent(IndexContent content)
+        public bool UpdateIndexContent(IndexContentCrudViewModel content)
         {
             try
             {
-                db.IndexContents.Update(content);
+                var entity = db.IndexContents.Find(content.IndexContentId);
+                entity.AboutTitle = content.AboutTitle;
+                entity.AboutSubTitle = content.AboutSubTitle;
+                entity.AboutDescription = content.AboutDescription;
+                entity.FeatureTitle = content.FeatureTitle;
+                entity.FeatureSubTitle = content.FeatureSubTitle;
+                entity.FeatureDescription = content.FeatureDescription;
+                entity.FaqTitle = content.FaqTitle;
+                entity.FaqSubTitle = content.FaqSubTitle;
+                entity.FaqDescription = content.FaqDescription;
+                db.IndexContents.Update(entity);
                 db.SaveChanges();
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutTitle), "en", content.AboutTitleEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutTitle), "ar", content.AboutTitleAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutTitle), "ur", content.AboutTitleUr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutSubTitle), "en", content.AboutSubTitleEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutSubTitle), "ar", content.AboutSubTitleAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutSubTitle), "ur", content.AboutSubTitleUr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutDescription), "en", content.AboutDescriptionEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutDescription), "ar", content.AboutDescriptionAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutDescription), "ur", content.AboutDescriptionUr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureTitle), "en", content.FeatureTitleEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureTitle), "ar", content.FeatureTitleAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureTitle), "ur", content.FeatureTitleUr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureSubTitle), "en", content.FeatureSubTitleEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureSubTitle), "ar", content.FeatureSubTitleAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureSubTitle), "ur", content.FeatureSubTitleUr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureDescription), "en", content.FeatureDescriptionEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureDescription), "ar", content.FeatureDescriptionAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureDescription), "ur", content.FeatureDescriptionUr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqTitle), "en", content.FaqTitleEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqTitle), "ar", content.FaqTitleAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqTitle), "ur", content.FaqTitleUr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqSubTitle), "en", content.FaqSubTitleEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqSubTitle), "ar", content.FaqSubTitleAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqSubTitle), "ur", content.FaqSubTitleUr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqDescription), "en", content.FaqDescriptionEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqDescription), "ar", content.FaqDescriptionAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqDescription), "ur", content.FaqDescriptionUr);
                 return true;
             }
             catch
@@ -716,12 +792,37 @@ namespace Services
             }
         }
 
-        public bool UpdateContactUsContent(ContactUsContent content)
+        public bool UpdateContactUsContent(ContactUsContentCrudViewModel content)
         {
             try
             {
-                db.ContactUsContents.Update(content);
+                var entity = db.ContactUsContents.Find(content.ContactUsContentId);
+                entity.FirstSubTitle = content.FirstSubTitle;
+                entity.FirstTitle = content.FirstTitle;
+                entity.FristDescription = content.FristDescription;
+                entity.SecondSubTitle = content.SecondSubTitle;
+                entity.SecondTitle = content.SecondTitle;
+                entity.SecondDescription = content.SecondDescription;
+                db.ContactUsContents.Update(entity);
                 db.SaveChanges();
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FirstSubTitle), "en", content.FirstSubTitleEn);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FirstSubTitle), "ar", content.FirstSubTitleAr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FirstSubTitle), "ur", content.FirstSubTitleUr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FirstTitle), "en", content.FirstTitleEn);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FirstTitle), "ar", content.FirstTitleAr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FirstTitle), "ur", content.FirstTitleUr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FristDescription), "en", content.FristDescriptionEn);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FristDescription), "ar", content.FristDescriptionAr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FristDescription), "ur", content.FristDescriptionUr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondSubTitle), "en", content.SecondSubTitleEn);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondSubTitle), "ar", content.SecondSubTitleAr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondSubTitle), "ur", content.SecondSubTitleUr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondTitle), "en", content.SecondTitleEn);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondTitle), "ar", content.SecondTitleAr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondTitle), "ur", content.SecondTitleUr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondDescription), "en", content.SecondDescriptionEn);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondDescription), "ar", content.SecondDescriptionAr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondDescription), "ur", content.SecondDescriptionUr);
                 return true;
             }
             catch
@@ -730,11 +831,38 @@ namespace Services
             }
         }
 
-        public ContactUsContent GetContactUsContent()
+        public ContactUsContentCrudViewModel GetContactUsContent()
         {
             var item = db.ContactUsContents.FirstOrDefault();
-            item.ApplyTranslation(db);
-            return item;
+            var translations = db.EntityTranslations.Where(t => t.EntityName == nameof(ContactUsContent) && t.EntityId == item.ContactUsContentId).ToList();
+            return new ContactUsContentCrudViewModel
+            {
+                ContactUsContentId = item.ContactUsContentId,
+                FirstSubTitle = item.FirstSubTitle,
+                FirstTitle = item.FirstTitle,
+                FristDescription = item.FristDescription,
+                SecondSubTitle = item.SecondSubTitle,
+                SecondTitle = item.SecondTitle,
+                SecondDescription = item.SecondDescription,
+                FirstSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FirstSubTitle) && t.Culture == "en")?.Value,
+                FirstSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FirstSubTitle) && t.Culture == "ar")?.Value,
+                FirstSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FirstSubTitle) && t.Culture == "ur")?.Value,
+                FirstTitleEn = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FirstTitle) && t.Culture == "en")?.Value,
+                FirstTitleAr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FirstTitle) && t.Culture == "ar")?.Value,
+                FirstTitleUr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FirstTitle) && t.Culture == "ur")?.Value,
+                FristDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FristDescription) && t.Culture == "en")?.Value,
+                FristDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FristDescription) && t.Culture == "ar")?.Value,
+                FristDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FristDescription) && t.Culture == "ur")?.Value,
+                SecondSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondSubTitle) && t.Culture == "en")?.Value,
+                SecondSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondSubTitle) && t.Culture == "ar")?.Value,
+                SecondSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondSubTitle) && t.Culture == "ur")?.Value,
+                SecondTitleEn = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondTitle) && t.Culture == "en")?.Value,
+                SecondTitleAr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondTitle) && t.Culture == "ar")?.Value,
+                SecondTitleUr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondTitle) && t.Culture == "ur")?.Value,
+                SecondDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondDescription) && t.Culture == "en")?.Value,
+                SecondDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondDescription) && t.Culture == "ar")?.Value,
+                SecondDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondDescription) && t.Culture == "ur")?.Value
+            };
         }
 
         public List<DownloadLinkGroupViewModel> GetDownloadLinkGoroups()
@@ -753,9 +881,28 @@ namespace Services
             return content;
         }
 
-        
+
 
 
         #endregion Contents
+
+        private void SaveTranslation(string entityName, int entityId, string property, string culture, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return;
+            var tr = db.EntityTranslations.FirstOrDefault(t => t.EntityName == entityName && t.EntityId == entityId && t.Property == property && t.Culture == culture);
+            if (tr == null)
+            {
+                tr = new EntityTranslation
+                {
+                    EntityName = entityName,
+                    EntityId = entityId,
+                    Property = property,
+                    Culture = culture
+                };
+                db.EntityTranslations.Add(tr);
+            }
+            tr.Value = value;
+            db.SaveChanges();
+        }
     }
 }

--- a/Twelve/Areas/Admin/Controllers/BlogController.cs
+++ b/Twelve/Areas/Admin/Controllers/BlogController.cs
@@ -102,6 +102,7 @@ namespace Twelve.Areas.Admin.Controllers
             }
             if (blogRepository.Create(blog,imageProduct))
             {
+                blogRepository.SaveTranslations(blog);
                 return RedirectToAction("Index");
             }
             else
@@ -138,6 +139,7 @@ namespace Twelve.Areas.Admin.Controllers
             }
             if (blogRepository.Update(blog , imageProduct))
             {
+                blogRepository.SaveTranslations(blog);
                 return RedirectToAction("Index");
             }
             else

--- a/Twelve/Areas/Admin/Controllers/BlogGroupsController.cs
+++ b/Twelve/Areas/Admin/Controllers/BlogGroupsController.cs
@@ -32,7 +32,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "دسته بندی های اخبار"))
             {
-                return View();
+                return View(new BlogGroupCrudViewModel());
             }
             else
             {
@@ -42,16 +42,19 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Create")]
-        public IActionResult Create(BlogGroup blogGroup)
+        public IActionResult Create(BlogGroupCrudViewModel blogGroup)
         {
-            if (blogGroupsRepository.Create(blogGroup))
+            var entity = new BlogGroup { GroupName = blogGroup.GroupName, ParentId = blogGroup.ParentId };
+            if (blogGroupsRepository.Create(entity))
             {
+                blogGroup.BlogGroupId = entity.BlogGroupId;
+                blogGroupsRepository.SaveTranslations(blogGroup);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                return View();
+                return View(blogGroup);
             }
         }
 
@@ -60,7 +63,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "دسته بندی های اخبار"))
             {
-                var content = blogGroupsRepository.GetByID(InfoID);
+                var content = blogGroupsRepository.GetForEdit(InfoID);
                 return View(content);
             }
             else
@@ -71,16 +74,18 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Update/{InfoID}")]
-        public IActionResult Update(BlogGroup blogGroup)
+        public IActionResult Update(BlogGroupCrudViewModel blogGroup)
         {
-            if (blogGroupsRepository.Update(blogGroup))
+            var entity = new BlogGroup { BlogGroupId = blogGroup.BlogGroupId, GroupName = blogGroup.GroupName, ParentId = blogGroup.ParentId };
+            if (blogGroupsRepository.Update(entity))
             {
+                blogGroupsRepository.SaveTranslations(blogGroup);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = blogGroupsRepository.GetByID(blogGroup.BlogGroupId);
+                var content = blogGroupsRepository.GetForEdit(blogGroup.BlogGroupId);
                 return View(content);
             }
         }

--- a/Twelve/Areas/Admin/Controllers/FaqController.cs
+++ b/Twelve/Areas/Admin/Controllers/FaqController.cs
@@ -52,6 +52,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (faqsRepository.Create(faqs))
             {
+                faqsRepository.SaveTranslations(faqs);
                 return RedirectToAction("Index");
             }
             else
@@ -82,6 +83,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (faqsRepository.Update(faqs))
             {
+                faqsRepository.SaveTranslations(faqs);
                 return RedirectToAction("Index");
             }
             else

--- a/Twelve/Areas/Admin/Controllers/FaqsGroupController.cs
+++ b/Twelve/Areas/Admin/Controllers/FaqsGroupController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Services;
+using ViewModels;
 
 namespace Twelve.Areas.Admin.Controllers
 {
@@ -31,7 +32,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "دسته بندی های اخبار"))
             {
-                return View();
+                return View(new FaqGroupCrudViewModel());
             }
             else
             {
@@ -41,16 +42,19 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Create")]
-        public IActionResult Create(FaqGroup faqGroup)
+        public IActionResult Create(FaqGroupCrudViewModel faqGroup)
         {
-            if (faqsRepository.CreateGroup(faqGroup))
+            FaqGroup entity = new FaqGroup { GroupName = faqGroup.GroupName, ParentId = faqGroup.ParentId };
+            if (faqsRepository.CreateGroup(entity))
             {
+                faqGroup.FaqGroupId = entity.FaqGroupId;
+                faqsRepository.SaveGroupTranslations(faqGroup);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                return View();
+                return View(faqGroup);
             }
         }
 
@@ -59,7 +63,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "دسته بندی های اخبار"))
             {
-                var content = faqsRepository.GetGroupByID(InfoID);
+                var content = faqsRepository.GetGroupForEdit(InfoID);
                 return View(content);
             }
             else
@@ -70,16 +74,18 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Update/{InfoID}")]
-        public IActionResult Update(FaqGroup faqGroup)
+        public IActionResult Update(FaqGroupCrudViewModel faqGroup)
         {
-            if (faqsRepository.UpdateGroup(faqGroup))
+            FaqGroup entity = new FaqGroup { FaqGroupId = faqGroup.FaqGroupId, GroupName = faqGroup.GroupName, ParentId = faqGroup.ParentId };
+            if (faqsRepository.UpdateGroup(entity))
             {
+                faqsRepository.SaveGroupTranslations(faqGroup);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = faqsRepository.GetByID(faqGroup.FaqGroupId);
+                var content = faqsRepository.GetGroupForEdit(faqGroup.FaqGroupId);
                 return View(content);
             }
         }

--- a/Twelve/Areas/Admin/Controllers/FeaturesController.cs
+++ b/Twelve/Areas/Admin/Controllers/FeaturesController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Services;
+using ViewModels;
 
 namespace Twelve.Areas.Admin.Controllers
 {
@@ -51,7 +52,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "ویژگی ها"))
             {
-                return View();
+                return View(new FeatureCrudViewModel());
             }
             else
             {
@@ -61,32 +62,43 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Create")]
-        public IActionResult Create(Feature feature, IFormFile imageProduct, IFormFile animeteFile, IFormFile imageFAProduct, IFormFile imageSAProduct , IFormFile introduceProduct)
+        public IActionResult Create(FeatureCrudViewModel feature, IFormFile imageProduct, IFormFile animeteFile, IFormFile imageFAProduct, IFormFile imageSAProduct , IFormFile introduceProduct)
         {
             if (imageProduct == null)
             {
                 ViewBag.Message = "لطفا تصویر مربوطه را وارد کنید";
-                return View();
+                return View(feature);
             }
             if (animeteFile == null)
             {
                 ViewBag.Message = "لطفا فایل انیمیشن مربوطه را وارد کنید";
-                return View();
+                return View(feature);
             }
             if (introduceProduct == null)
             {
                 ViewBag.Message = "لطفا تصویر معرفی نرم افزار در صفحه اول مربوطه را وارد کنید";
-                return View();
+                return View(feature);
             }
-
-            if (featuresRepository.Create(feature, imageProduct,animeteFile,imageFAProduct,imageSAProduct,introduceProduct))
+            var entity = new Feature
             {
+                Title = feature.Title,
+                ShortDescription = feature.ShortDescription,
+                FirstDescription = feature.FirstDescription,
+                FirstArticleTitle = feature.FirstArticleTitle,
+                FirstArticleDescription = feature.FirstArticleDescription,
+                SecondArticleTitle = feature.SecondArticleTitle,
+                SecondArticleDescription = feature.SecondArticleDescription
+            };
+            if (featuresRepository.Create(entity, imageProduct, animeteFile, imageFAProduct, imageSAProduct, introduceProduct))
+            {
+                feature.FeatureId = entity.FeatureId;
+                featuresRepository.SaveTranslations(feature);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                return View();
+                return View(feature);
             }
         }
 
@@ -95,7 +107,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "ویژگی ها"))
             {
-                var content = featuresRepository.GetByID(featureID);
+                var content = featuresRepository.GetForEdit(featureID);
                 return View(content);
             }
             else
@@ -106,16 +118,33 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Update/{FeatureID}")]
-        public IActionResult Update(Feature feature, IFormFile imageProduct, IFormFile animeteFile, IFormFile imageFAProduct, IFormFile imageSAProduct, IFormFile introduceProduct)
+        public IActionResult Update(FeatureCrudViewModel feature, IFormFile imageProduct, IFormFile animeteFile, IFormFile imageFAProduct, IFormFile imageSAProduct, IFormFile introduceProduct)
         {
-            if (featuresRepository.Update(feature, imageProduct, animeteFile, imageFAProduct, imageSAProduct, introduceProduct))
+            var entity = new Feature
             {
+                FeatureId = feature.FeatureId,
+                Title = feature.Title,
+                ShortDescription = feature.ShortDescription,
+                FirstDescription = feature.FirstDescription,
+                FirstArticleTitle = feature.FirstArticleTitle,
+                FirstArticleDescription = feature.FirstArticleDescription,
+                SecondArticleTitle = feature.SecondArticleTitle,
+                SecondArticleDescription = feature.SecondArticleDescription,
+                ImageName = feature.ImageName,
+                AnimateFilename = feature.AnimateFilename,
+                FirstArticleImage = feature.FirstArticleImage,
+                SecondArticleImage = feature.SecondArticleImage,
+                IntroduceImageName = feature.IntroduceImageName
+            };
+            if (featuresRepository.Update(entity, imageProduct, animeteFile, imageFAProduct, imageSAProduct, introduceProduct))
+            {
+                featuresRepository.SaveTranslations(feature);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = featuresRepository.GetByID(feature.FeatureId);
+                var content = featuresRepository.GetForEdit(feature.FeatureId);
                 return View(content);
             }
         }
@@ -204,7 +233,7 @@ namespace Twelve.Areas.Admin.Controllers
             if (adminRepository.CheckPermission(User.Identity.Name, "ویژگی ها"))
             {
                 ViewBag.FeatureID = FeatureID;
-                return View();
+                return View(new FeatureItemCrudViewModel { FeatureId = FeatureID });
             }
             else
             {
@@ -214,17 +243,25 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("CreateItem/{FeatureID}")]
-        public IActionResult CreateItem(FeatureItem featureItem, IFormFile imageProduct)
+        public IActionResult CreateItem(FeatureItemCrudViewModel featureItem, IFormFile imageProduct)
         {
-            if (featuresRepository.CreateItem(featureItem, imageProduct))
+            var entity = new FeatureItem
             {
+                FeatureId = featureItem.FeatureId,
+                Title = featureItem.Title,
+                ShortDescription = featureItem.ShortDescription
+            };
+            if (featuresRepository.CreateItem(entity, imageProduct))
+            {
+                featureItem.FeaturesItemId = entity.FeaturesItemId;
+                featuresRepository.SaveItemTranslations(featureItem);
                 return RedirectToAction("ShowItems", new { FeatureID = featureItem.FeatureId });
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
                 ViewBag.FeatureID = featureItem.FeatureId;
-                return View();
+                return View(featureItem);
             }
         }
 
@@ -233,7 +270,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "ویژگی ها"))
             {
-                var content = featuresRepository.GetItemByID(InfoID);
+                var content = featuresRepository.GetItemForEdit(InfoID);
                 return View(content);
             }
             else
@@ -244,16 +281,25 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("UpdateItem/{InfoID}")]
-        public IActionResult UpdateItem(FeatureItem featureItem, IFormFile imageProduct)
+        public IActionResult UpdateItem(FeatureItemCrudViewModel featureItem, IFormFile imageProduct)
         {
-            if (featuresRepository.UpdateItem(featureItem, imageProduct))
+            var entity = new FeatureItem
             {
+                FeaturesItemId = featureItem.FeaturesItemId,
+                FeatureId = featureItem.FeatureId,
+                Title = featureItem.Title,
+                ShortDescription = featureItem.ShortDescription,
+                ImageName = featureItem.ImageName
+            };
+            if (featuresRepository.UpdateItem(entity, imageProduct))
+            {
+                featuresRepository.SaveItemTranslations(featureItem);
                 return RedirectToAction("ShowItems", new { FeatureID = featureItem.FeatureId });
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = featuresRepository.GetItemByID(featureItem.FeaturesItemId);
+                var content = featuresRepository.GetItemForEdit(featureItem.FeaturesItemId);
                 return View(content);
             }
         }

--- a/Twelve/Areas/Admin/Controllers/HomeController.cs
+++ b/Twelve/Areas/Admin/Controllers/HomeController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Services;
+using ViewModels;
 
 namespace Twelve.Areas.Admin.Controllers
 {
@@ -72,7 +73,7 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("IndexContent")]
-        public IActionResult IndexContent(IndexContent indexContent)
+        public IActionResult IndexContent(IndexContentCrudViewModel indexContent)
         {
             if (siteRepository.UpdateIndexContent(indexContent))
             {
@@ -136,7 +137,7 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("ContactUsContent")]
-        public IActionResult ContactUsContent(ContactUsContent contactUsContent)
+        public IActionResult ContactUsContent(ContactUsContentCrudViewModel contactUsContent)
         {
             if (siteRepository.UpdateContactUsContent(contactUsContent))
             {
@@ -158,7 +159,7 @@ namespace Twelve.Areas.Admin.Controllers
             if (adminRepository.CheckPermission(User.Identity.Name, "تنظیمات"))
             {
                 IFaqsRepository faqsRepository = new FaqsRepository();
-                var content = faqsRepository.GetFaqContent();
+                var content = faqsRepository.GetFaqContentForEdit();
                 return View(content);
             }
             else
@@ -169,20 +170,20 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("FaqContent")]
-        public IActionResult FaqContent(FaqContent aboutUsContent)
+        public IActionResult FaqContent(FaqContentCrudViewModel aboutUsContent)
         {
             IFaqsRepository faqsRepository = new FaqsRepository();
 
             if (faqsRepository.UpdateFaqContent(aboutUsContent))
             {
                 ViewBag.Message = "عملیات با موفقیت انجام شد";
-                var content = faqsRepository.GetFaqContent();
+                var content = faqsRepository.GetFaqContentForEdit();
                 return View(content);
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = faqsRepository.GetFaqContent();
+                var content = faqsRepository.GetFaqContentForEdit();
                 return View(content);
             }
         }
@@ -193,7 +194,7 @@ namespace Twelve.Areas.Admin.Controllers
             if (adminRepository.CheckPermission(User.Identity.Name, "تنظیمات"))
             {
                 IFeaturesRepository featuresRepository = new FeaturesRepository();
-                var content = featuresRepository.GetFeaturesContent();
+                var content = featuresRepository.GetFeaturesContentForEdit();
                 return View(content);
             }
             else
@@ -204,20 +205,20 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("AppMenuContent")]
-        public IActionResult AppMenuContent(FeaturesContent featuresContent)
+        public IActionResult AppMenuContent(FeaturesContentCrudViewModel featuresContent)
         {
             IFeaturesRepository featuresRepository = new FeaturesRepository();
 
             if (featuresRepository.UpdateFeaturesContent(featuresContent))
             {
                 ViewBag.Message = "عملیات با موفقیت انجام شد";
-                var content = featuresRepository.GetFeaturesContent();
+                var content = featuresRepository.GetFeaturesContentForEdit();
                 return View(content);
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = featuresRepository.GetFeaturesContent();
+                var content = featuresRepository.GetFeaturesContentForEdit();
                 return View(content);
             }
         }

--- a/Twelve/Areas/Admin/Views/Blog/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/Blog/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model ViewModels.BlogCrudViewModel
+@model ViewModels.BlogCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -16,21 +16,72 @@
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-9">
-                                    <div class="form-group">
-                                        <label for="Title">عنوان</label>
-                                        <input type="text" class="form-control w-100" name="Title" id="Title" placeholder="عنوان را وارد کنید"/>
-                                        @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="ShortDescription">توضیح کوتاه</label>
-                                        <textarea rows="5" class="form-control w-100" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید"></textarea>
-                                        @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
-
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="Description">متن</label>
-                                        <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="متن را وارد کنید"></textarea>
-                                        @Html.ValidationMessageFor(model => model.Description, "", new { @class = "text-danger" })
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" class="form-control w-100" name="Title" id="Title" placeholder="عنوان را وارد کنید" />
+                                                @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescription">توضیح کوتاه</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید"></textarea>
+                                                @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="Description">متن</label>
+                                                <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="متن را وارد کنید"></textarea>
+                                                @Html.ValidationMessageFor(model => model.Description, "", new { @class = "text-danger" })
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleEn" id="TitleEn" value="@Model?.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionEn">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionEn" id="ShortDescriptionEn">@Model?.ShortDescriptionEn</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionEn">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionEn" id="DescriptionEn">@Model?.DescriptionEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleAr" id="TitleAr" value="@Model?.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionAr">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionAr" id="ShortDescriptionAr">@Model?.ShortDescriptionAr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionAr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionAr" id="DescriptionAr">@Model?.DescriptionAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleUr" id="TitleUr" value="@Model?.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionUr">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionUr" id="ShortDescriptionUr">@Model?.ShortDescriptionUr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionUr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionUr" id="DescriptionUr">@Model?.DescriptionUr</textarea>
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="form-group ">
                                         <div class="text-center">
@@ -53,7 +104,7 @@
                                     </div>
                                     <div class="form-group">
                                         <label for="StudyTime">زمان مطالعه (دقیقه)</label>
-                                        <input type="number" min="1" value="1" class="form-control w-100" name="StudyTime" id="StudyTime"  />
+                                        <input type="number" min="1" value="1" class="form-control w-100" name="StudyTime" id="StudyTime" />
                                     </div>
                                     <div class="form-check">
                                         @Html.CheckBoxFor(model => model.IsSlider,htmlAttributes: new {@class="form-check-input"})
@@ -71,7 +122,7 @@
                                         @foreach (var item in Model.Groups)
                                         {
                                             <div class="form-check m-2">
-                                                <input type="checkbox" class="form-check-input" id="@item.GroupID" name="SelectedGroups" value="@item.GroupID">
+                                                <input type="checkbox" class="form-check-input" id="@item.GroupID" @((Model.SelectedGroups != null && Model.SelectedGroups.Any(s => s == item.GroupID) ? "checked" : "")) name="SelectedGroups" value="@item.GroupID">
                                                 <label class="form-check-label" for="@item.GroupID">@item.GroupName</label>
                                             </div>
                                         }
@@ -96,6 +147,9 @@
     <script>
         $(function () {
             $('#Description').ckeditor();
+            $('#DescriptionEn').ckeditor();
+            $('#DescriptionAr').ckeditor();
+            $('#DescriptionUr').ckeditor();
         });
     </script>
 }

--- a/Twelve/Areas/Admin/Views/Blog/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/Blog/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model ViewModels.BlogCrudViewModel
+@model ViewModels.BlogCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -18,17 +18,69 @@
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-9">
-                                    <div class="form-group">
-                                        <label for="Title">عنوان</label>
-                                        <input type="text" class="form-control w-100" value="@Model.Title"  name="Title" id="Title" placeholder="عنوان را وارد کنید" />
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="ShortDescription">توضیح کوتاه</label>
-                                        <textarea rows="5" class="form-control w-100" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">@Model.ShortDescription</textarea>
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="Description">متن</label>
-                                        <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="متن را وارد کنید">@Model.Description</textarea>
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" class="form-control w-100" value="@Model.Title" name="Title" id="Title" placeholder="عنوان را وارد کنید" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescription">توضیح کوتاه</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">@Model.ShortDescription</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="Description">متن</label>
+                                                <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="متن را وارد کنید">@Model.Description</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleEn" id="TitleEn" value="@Model.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionEn">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionEn" id="ShortDescriptionEn">@Model.ShortDescriptionEn</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionEn">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionEn" id="DescriptionEn">@Model.DescriptionEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleAr" id="TitleAr" value="@Model.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionAr">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionAr" id="ShortDescriptionAr">@Model.ShortDescriptionAr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionAr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionAr" id="DescriptionAr">@Model.DescriptionAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleUr" id="TitleUr" value="@Model.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionUr">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionUr" id="ShortDescriptionUr">@Model.ShortDescriptionUr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionUr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionUr" id="DescriptionUr">@Model.DescriptionUr</textarea>
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="form-group ">
                                         <div class="text-center">
@@ -78,7 +130,6 @@
                             </div>
                         </div>
                         <!-- /.card-body -->
-
                         <div class="card-footer">
                             <button type="submit" class="btn btn-warning">ثبت</button>
                             <a href="/Admin/Blog" class="btn btn-info float-left">بازگشت به لیست</a>
@@ -94,6 +145,9 @@
     <script>
         $(function () {
             $('#Description').ckeditor();
+            $('#DescriptionEn').ckeditor();
+            $('#DescriptionAr').ckeditor();
+            $('#DescriptionUr').ckeditor();
         });
     </script>
 }

--- a/Twelve/Areas/Admin/Views/BlogGroups/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/BlogGroups/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.BlogGroup
+@model ViewModels.BlogGroupCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -10,25 +10,48 @@
                             <span class="text-dark mx-2">@ViewBag.Message</span>
                         </h3>
                     </div>
-                    <!-- /.card-header -->
-                    <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="GroupName">عنوان</label>
-                                <input type="text" name="GroupName" class="form-control" id="GroupName" placeholder="عنوان را وارد کنید">
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupName">عنوان</label>
+                                        <input type="text" name="GroupName" class="form-control" id="GroupName" value="@Model.GroupName" placeholder="عنوان را وارد کنید" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameEn">Title</label>
+                                        <input type="text" name="GroupNameEn" class="form-control" id="GroupNameEn" value="@Model.GroupNameEn" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameAr">Title</label>
+                                        <input type="text" name="GroupNameAr" class="form-control" id="GroupNameAr" value="@Model.GroupNameAr" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameUr">Title</label>
+                                        <input type="text" name="GroupNameUr" class="form-control" id="GroupNameUr" value="@Model.GroupNameUr" />
+                                    </div>
+                                </div>
                             </div>
                         </div>
-                        <!-- /.card-body -->
-
                         <div class="card-footer">
                             <button type="submit" class="btn btn-success">ثبت</button>
                             <a href="/Admin/BlogGroups" class="btn btn-info float-left">بازگشت به لیست</a>
                         </div>
                     </form>
                 </div>
-                <!-- /.card -->
             </div>
         </div>
-    </div><!-- /.container-fluid -->
+    </div>
 </div>

--- a/Twelve/Areas/Admin/Views/BlogGroups/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/BlogGroups/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.BlogGroup
+@model ViewModels.BlogGroupCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -10,27 +10,50 @@
                             <span class="text-dark mx-2">@ViewBag.Message</span>
                         </h3>
                     </div>
-                    <!-- /.card-header -->
-                    <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
                         @Html.HiddenFor(m => m.BlogGroupId)
                         @Html.HiddenFor(m => m.ParentId)
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="GroupName">عنوان</label>
-                                <input type="text" name="GroupName" class="form-control" value="@Model.GroupName" id="GroupName" placeholder="عنوان را وارد کنید">
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupName">عنوان</label>
+                                        <input type="text" name="GroupName" class="form-control" id="GroupName" value="@Model.GroupName" placeholder="عنوان را وارد کنید" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameEn">Title</label>
+                                        <input type="text" name="GroupNameEn" class="form-control" id="GroupNameEn" value="@Model.GroupNameEn" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameAr">Title</label>
+                                        <input type="text" name="GroupNameAr" class="form-control" id="GroupNameAr" value="@Model.GroupNameAr" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameUr">Title</label>
+                                        <input type="text" name="GroupNameUr" class="form-control" id="GroupNameUr" value="@Model.GroupNameUr" />
+                                    </div>
+                                </div>
                             </div>
                         </div>
-                        <!-- /.card-body -->
-
                         <div class="card-footer">
                             <button type="submit" class="btn btn-warning">ثبت</button>
                             <a href="/Admin/BlogGroups" class="btn btn-info float-left">بازگشت به لیست</a>
                         </div>
                     </form>
                 </div>
-                <!-- /.card -->
             </div>
         </div>
-    </div><!-- /.container-fluid -->
+    </div>
 </div>

--- a/Twelve/Areas/Admin/Views/Faq/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/Faq/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model ViewModels.FaqsCrudViewModel
+@model ViewModels.FaqsCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -16,13 +16,53 @@
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-9">
-                                    <div class="form-group">
-                                        <label for="Question">سوال</label>
-                                        <textarea rows="5" class="form-control w-100" name="Question" id="Question" placeholder="سوال را وارد کنید"></textarea>
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="Answer">پاسخ</label>
-                                        <textarea rows="5" class="form-control w-100" name="Answer" id="Answer" placeholder="پاسخ را وارد کنید"></textarea>
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Question">سوال</label>
+                                                <textarea rows="5" class="form-control w-100" name="Question" id="Question" placeholder="سوال را وارد کنید"></textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="Answer">پاسخ</label>
+                                                <textarea rows="5" class="form-control w-100" name="Answer" id="Answer" placeholder="پاسخ را وارد کنید"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionEn">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionEn" id="QuestionEn"></textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerEn">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerEn" id="AnswerEn"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionAr">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionAr" id="QuestionAr"></textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerAr">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerAr" id="AnswerAr"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionUr">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionUr" id="QuestionUr"></textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerUr">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerUr" id="AnswerUr"></textarea>
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="form-check">
                                         @Html.CheckBoxFor(model => model.IsMain,htmlAttributes: new {@class="form-check-input"})
@@ -49,7 +89,6 @@
                             </div>
                         </div>
                         <!-- /.card-body -->
-
                         <div class="card-footer">
                             <button type="submit" class="btn btn-success">ثبت</button>
                             <a href="/Admin/Faq" class="btn btn-info float-left">بازگشت به لیست</a>

--- a/Twelve/Areas/Admin/Views/Faq/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/Faq/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model ViewModels.FaqsCrudViewModel
+@model ViewModels.FaqsCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -13,17 +13,57 @@
                     <!-- /.card-header -->
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
-                        @Html.HiddenFor(m=> m.FaqID)
+                        @Html.HiddenFor(m => m.FaqID)
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-9">
-                                    <div class="form-group">
-                                        <label for="Question">سوال</label>
-                                        <textarea rows="5" class="form-control w-100" name="Question" id="Question" placeholder="سوال را وارد کنید">@Model.Question</textarea>
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="Answer">پاسخ</label>
-                                        <textarea rows="5" class="form-control w-100" name="Answer" id="Answer" placeholder="پاسخ را وارد کنید">@Model.Answer</textarea>
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Question">سوال</label>
+                                                <textarea rows="5" class="form-control w-100" name="Question" id="Question" placeholder="سوال را وارد کنید">@Model.Question</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="Answer">پاسخ</label>
+                                                <textarea rows="5" class="form-control w-100" name="Answer" id="Answer" placeholder="پاسخ را وارد کنید">@Model.Answer</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionEn">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionEn" id="QuestionEn">@Model.QuestionEn</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerEn">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerEn" id="AnswerEn">@Model.AnswerEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionAr">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionAr" id="QuestionAr">@Model.QuestionAr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerAr">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerAr" id="AnswerAr">@Model.AnswerAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionUr">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionUr" id="QuestionUr">@Model.QuestionUr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerUr">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerUr" id="AnswerUr">@Model.AnswerUr</textarea>
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="form-check">
                                         @Html.CheckBoxFor(model => model.IsMain,htmlAttributes: new {@class="form-check-input"})
@@ -50,9 +90,8 @@
                             </div>
                         </div>
                         <!-- /.card-body -->
-
                         <div class="card-footer">
-                            <button type="submit" class="btn btn-success">ثبت</button>
+                            <button type="submit" class="btn btn-warning">ثبت</button>
                             <a href="/Admin/Faq" class="btn btn-info float-left">بازگشت به لیست</a>
                         </div>
                     </form>

--- a/Twelve/Areas/Admin/Views/FaqsGroup/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/FaqsGroup/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.FaqGroup
+﻿@model ViewModels.FaqGroupCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -14,9 +14,37 @@
                     <!-- form start -->
                     <form role="form" method="post">
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="GroupName">عنوان</label>
-                                <input type="text" name="GroupName" class="form-control" id="GroupName" placeholder="عنوان را وارد کنید">
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupName">عنوان</label>
+                                        <input type="text" name="GroupName" class="form-control" id="GroupName" value="@Model.GroupName" placeholder="عنوان را وارد کنید" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameEn">Title</label>
+                                        <input type="text" name="GroupNameEn" class="form-control" id="GroupNameEn" value="@Model.GroupNameEn" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameAr">Title</label>
+                                        <input type="text" name="GroupNameAr" class="form-control" id="GroupNameAr" value="@Model.GroupNameAr" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameUr">Title</label>
+                                        <input type="text" name="GroupNameUr" class="form-control" id="GroupNameUr" value="@Model.GroupNameUr" />
+                                    </div>
+                                </div>
                             </div>
                         </div>
                         <!-- /.card-body -->

--- a/Twelve/Areas/Admin/Views/FaqsGroup/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/FaqsGroup/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.FaqGroup
+﻿@model ViewModels.FaqGroupCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -16,9 +16,37 @@
                         @Html.HiddenFor(m=> m.FaqGroupId)
                         @Html.HiddenFor(m=> m.ParentId)
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="GroupName">عنوان</label>
-                                <input type="text" name="GroupName" class="form-control" value="@Model.GroupName" id="GroupName" placeholder="عنوان را وارد کنید">
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupName">عنوان</label>
+                                        <input type="text" name="GroupName" class="form-control" id="GroupName" value="@Model.GroupName" placeholder="عنوان را وارد کنید" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameEn">Title</label>
+                                        <input type="text" name="GroupNameEn" class="form-control" id="GroupNameEn" value="@Model.GroupNameEn" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameAr">Title</label>
+                                        <input type="text" name="GroupNameAr" class="form-control" id="GroupNameAr" value="@Model.GroupNameAr" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameUr">Title</label>
+                                        <input type="text" name="GroupNameUr" class="form-control" id="GroupNameUr" value="@Model.GroupNameUr" />
+                                    </div>
+                                </div>
                             </div>
                         </div>
                         <!-- /.card-body -->

--- a/Twelve/Areas/Admin/Views/Features/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/Features/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.Feature
+@model ViewModels.FeatureCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -14,22 +14,76 @@
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" id="Title" placeholder="عنوان را وارد کنید">
-                                @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
-
-                            </div>
-                            <div class="form-group">
-                                <label for="ShortDescription">توضیح کوتاه</label>
-                                <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
-                                @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
-
-                            </div>
-                            <div class="form-group">
-                                <label for="FirstDescription">توضیح</label>
-                                <textarea rows="5" class="form-control w-100" name="FirstDescription" id="FirstDescription" placeholder="توضیح را وارد کنید"></textarea>
-                                @Html.ValidationMessageFor(model => model.FirstDescription, "", new { @class = "text-danger" })
+                            <div class="row">
+                                <div class="col-12">
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" name="Title" class="form-control" id="Title" value="@Model?.Title" placeholder="عنوان را وارد کنید">
+                                                @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescription">توضیح کوتاه</label>
+                                                <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" value="@Model?.ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                                                @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
+                                            </div>
+                        <div class="form-group">
+                                                <label for="FirstDescription">توضیح</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescription" id="FirstDescription" placeholder="توضیح را وارد کنید">@Model?.FirstDescription</textarea>
+                                                @Html.ValidationMessageFor(model => model.FirstDescription, "", new { @class = "text-danger" })
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model?.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionEn">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionEn" id="ShortDescriptionEn" value="@Model?.ShortDescriptionEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionEn">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionEn" id="FirstDescriptionEn">@Model?.FirstDescriptionEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model?.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionAr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionAr" id="ShortDescriptionAr" value="@Model?.ShortDescriptionAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionAr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionAr" id="FirstDescriptionAr">@Model?.FirstDescriptionAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model?.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionUr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionUr" id="ShortDescriptionUr" value="@Model?.ShortDescriptionUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionUr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionUr" id="FirstDescriptionUr">@Model?.FirstDescriptionUr</textarea>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">
@@ -67,11 +121,11 @@
                                 </div>
                                 <div class="form-group m-3">
                                     <label for="FirstArticleTitle">عنوان مقاله اول</label>
-                                    <input type="text" class="form-control" name="FirstArticleTitle" id="FirstArticleTitle" placeholder="عنوان مقاله اول را وارد کنید">
+                                    <input type="text" class="form-control" name="FirstArticleTitle" id="FirstArticleTitle" value="@Model?.FirstArticleTitle" placeholder="عنوان مقاله اول را وارد کنید">
                                 </div>
                                 <div class="form-group m-3">
                                     <label for="FirstArticleDescription">توضیح مقاله اول</label>
-                                    <textarea rows="5" class="form-control w-100" name="FirstArticleDescription" id="FirstArticleDescription" placeholder="توضیح مقاله اول را وارد کنید"></textarea>
+                                    <textarea rows="5" class="form-control w-100" name="FirstArticleDescription" id="FirstArticleDescription" placeholder="توضیح مقاله اول را وارد کنید">@Model?.FirstArticleDescription</textarea>
                                 </div>
                                 <div class="form-group m-3 ">
                                     <div class="text-center">
@@ -91,11 +145,11 @@
                                 </div>
                                 <div class="form-group m-3">
                                     <label for="SecondArticleTitle">عنوان مقاله دوم</label>
-                                    <input type="text" class="form-control" name="SecondArticleTitle" id="SecondArticleTitle" placeholder="عنوان مقاله دوم را وارد کنید">
+                                    <input type="text" class="form-control" name="SecondArticleTitle" id="SecondArticleTitle" value="@Model?.SecondArticleTitle" placeholder="عنوان مقاله دوم را وارد کنید">
                                 </div>
                                 <div class="form-group m-3">
                                     <label for="SecondArticleDescription">توضیح مقاله دوم</label>
-                                    <textarea rows="5" class="form-control w-100" name="SecondArticleDescription" id="SecondArticleDescription" placeholder="توضیح مقاله دوم را وارد کنید"></textarea>
+                                    <textarea rows="5" class="form-control w-100" name="SecondArticleDescription" id="SecondArticleDescription" placeholder="توضیح مقاله دوم را وارد کنید">@Model?.SecondArticleDescription</textarea>
                                 </div>
                                 <div class="form-group m-3 ">
                                     <div class="text-center">
@@ -109,8 +163,6 @@
                                     </div>
                                 </div>
                             </div>
-                            
-                            
                         </div>
                         <!-- /.card-body -->
 

--- a/Twelve/Areas/Admin/Views/Features/CreateItem.cshtml
+++ b/Twelve/Areas/Admin/Views/Features/CreateItem.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.FeatureItem
+@model ViewModels.FeatureItemCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -13,15 +13,55 @@
                     <!-- /.card-header -->
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
-                        <input type="hidden" name="FeatureID" value="@ViewBag.FeatureID" />
+                        <input type="hidden" name="FeatureId" value="@Model.FeatureId" />
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" id="Title" placeholder="عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="ShortDescription">توضیح کوتاه</label>
-                                <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="Title">عنوان</label>
+                                        <input type="text" name="Title" class="form-control" id="Title" value="@Model?.Title" placeholder="عنوان را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescription">توضیح کوتاه</label>
+                                        <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" value="@Model?.ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleEn">Title</label>
+                                        <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model?.TitleEn" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionEn">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionEn" id="ShortDescriptionEn" value="@Model?.ShortDescriptionEn" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleAr">Title</label>
+                                        <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model?.TitleAr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionAr">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionAr" id="ShortDescriptionAr" value="@Model?.ShortDescriptionAr" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleUr">Title</label>
+                                        <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model?.TitleUr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionUr">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionUr" id="ShortDescriptionUr" value="@Model?.ShortDescriptionUr" />
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">
@@ -39,7 +79,7 @@
 
                         <div class="card-footer">
                             <button type="submit" class="btn btn-success">ثبت</button>
-                            <a href="/Admin/Features/ShowItems/@ViewBag.FeatureID" class="btn btn-info float-left">بازگشت به لیست</a>
+                            <a href="/Admin/Features/ShowItems/@Model.FeatureId" class="btn btn-info float-left">بازگشت به لیست</a>
                         </div>
                     </form>
                 </div>

--- a/Twelve/Areas/Admin/Views/Features/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/Features/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.Feature
+@model ViewModels.FeatureCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -13,29 +13,83 @@
                     <!-- /.card-header -->
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
-                        @Html.HiddenFor(m => m.FeatureId)
-                        @Html.HiddenFor(m => m.ImageName)
-                        @Html.HiddenFor(m => m.AnimateFilename)
-                        @Html.HiddenFor(m => m.FirstArticleImage)
-                        @Html.HiddenFor(m => m.SecondArticleImage)
-                        @Html.HiddenFor(m => m.IntroduceImageName)
+                        <input type="hidden" name="FeatureId" value="@Model.FeatureId" />
+                        <input type="hidden" name="ImageName" value="@Model.ImageName" />
+                        <input type="hidden" name="AnimateFilename" value="@Model.AnimateFilename" />
+                        <input type="hidden" name="FirstArticleImage" value="@Model.FirstArticleImage" />
+                        <input type="hidden" name="SecondArticleImage" value="@Model.SecondArticleImage" />
+                        <input type="hidden" name="IntroduceImageName" value="@Model.IntroduceImageName" />
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" id="Title" value="@Model.Title" placeholder="عنوان را وارد کنید">
-                                @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
-                            </div>
-                            <div class="form-group">
-                                <label for="ShortDescription">توضیح کوتاه</label>
-                                <input type="text" class="form-control" name="ShortDescription" value="@Model.ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
-                                @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
-
-                            </div>
-                            <div class="form-group">
-                                <label for="FirstDescription">توضیح</label>
-                                <textarea rows="5" class="form-control w-100" name="FirstDescription" id="FirstDescription" placeholder="توضیح را وارد کنید">@Model.FirstDescription</textarea>
-                                @Html.ValidationMessageFor(model => model.FirstDescription, "", new { @class = "text-danger" })
-
+                            <div class="row">
+                                <div class="col-12">
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" name="Title" class="form-control" id="Title" value="@Model.Title" placeholder="عنوان را وارد کنید">
+                                                @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescription">توضیح کوتاه</label>
+                                                <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" value="@Model.ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                                                @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescription">توضیح</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescription" id="FirstDescription" placeholder="توضیح را وارد کنید">@Model.FirstDescription</textarea>
+                                                @Html.ValidationMessageFor(model => model.FirstDescription, "", new { @class = "text-danger" })
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionEn">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionEn" id="ShortDescriptionEn" value="@Model.ShortDescriptionEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionEn">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionEn" id="FirstDescriptionEn">@Model.FirstDescriptionEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionAr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionAr" id="ShortDescriptionAr" value="@Model.ShortDescriptionAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionAr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionAr" id="FirstDescriptionAr">@Model.FirstDescriptionAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionUr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionUr" id="ShortDescriptionUr" value="@Model.ShortDescriptionUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionUr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionUr" id="FirstDescriptionUr">@Model.FirstDescriptionUr</textarea>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">
@@ -81,7 +135,7 @@
                                 </div>
                                 <div class="form-group m-3 ">
                                     <div class="text-center">
-                                        <img id="imageFAPreview" class="thumbnail w-100 my-5" src="~/Images/Features/@Model.FirstArticleImage" />
+                                        <img id="imageFAPreview" class="thumbnail my-5 w-100" src="~/Images/Features/@Model.FirstArticleImage" />
                                     </div>
                                     <div class="form-group">
                                         <div class="col-md-10">
@@ -105,7 +159,7 @@
                                 </div>
                                 <div class="form-group m-3 ">
                                     <div class="text-center">
-                                        <img id="imageSAPreview" class="thumbnail w-100 my-5" src="~/Images/Features/@Model.SecondArticleImage" />
+                                        <img id="imageSAPreview" class="thumbnail my-5 w-100" src="~/Images/Features/@Model.SecondArticleImage" />
                                     </div>
                                     <div class="form-group">
                                         <div class="col-md-10">
@@ -115,11 +169,8 @@
                                     </div>
                                 </div>
                             </div>
-
-
                         </div>
                         <!-- /.card-body -->
-
                         <div class="card-footer">
                             <button type="submit" class="btn btn-warning">ثبت</button>
                             <a href="/Admin/Features" class="btn btn-info float-left">بازگشت به لیست</a>
@@ -131,12 +182,12 @@
         </div>
     </div><!-- /.container-fluid -->
 </div>
-@section Ckeditor {
-    <script>
-        $(function () {
-            $('#FirstDescription').ckeditor();
-        });
-    </script>
+@section Ckeditor{
+<script>
+    $(function () {
+        $('#FirstDescription').ckeditor();
+    });
+</script>
 }
 <script>
     imageProduct.onchange = evt => {

--- a/Twelve/Areas/Admin/Views/Features/UpdateItem.cshtml
+++ b/Twelve/Areas/Admin/Views/Features/UpdateItem.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.FeatureItem
+@model ViewModels.FeatureItemCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -13,17 +13,57 @@
                     <!-- /.card-header -->
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
-                        <input type="hidden" name="FeaturesItemId" id="FeaturesItemId" value="@Model.FeaturesItemId" />
-                        <input type="hidden" name="ImageName" id="ImageName" value="@Model.ImageName" />
-                        <input type="hidden" name="FeatureId" id="FeatureId" value="@Model.FeatureId" />
+                        <input type="hidden" name="FeaturesItemId" value="@Model.FeaturesItemId" />
+                        <input type="hidden" name="ImageName" value="@Model.ImageName" />
+                        <input type="hidden" name="FeatureId" value="@Model.FeatureId" />
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" value="@Model.Title" id="Title" placeholder="عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="ShortDescription">توضیح کوتاه</label>
-                                <input type="text" class="form-control" name="ShortDescription" value="@Model.ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="Title">عنوان</label>
+                                        <input type="text" name="Title" class="form-control" id="Title" value="@Model.Title" placeholder="عنوان را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescription">توضیح کوتاه</label>
+                                        <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" value="@Model.ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleEn">Title</label>
+                                        <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model.TitleEn" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionEn">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionEn" id="ShortDescriptionEn" value="@Model.ShortDescriptionEn" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleAr">Title</label>
+                                        <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model.TitleAr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionAr">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionAr" id="ShortDescriptionAr" value="@Model.ShortDescriptionAr" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleUr">Title</label>
+                                        <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model.TitleUr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionUr">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionUr" id="ShortDescriptionUr" value="@Model.ShortDescriptionUr" />
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">

--- a/Twelve/Areas/Admin/Views/Home/AppMenuContent.cshtml
+++ b/Twelve/Areas/Admin/Views/Home/AppMenuContent.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.FeaturesContent
+﻿@model ViewModels.FeaturesContentCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">

--- a/Twelve/Areas/Admin/Views/Home/ContactUsContent.cshtml
+++ b/Twelve/Areas/Admin/Views/Home/ContactUsContent.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.ContactUsContent
+﻿@model ViewModels.ContactUsContentCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">

--- a/Twelve/Areas/Admin/Views/Home/FaqContent.cshtml
+++ b/Twelve/Areas/Admin/Views/Home/FaqContent.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.FaqContent
+﻿@model ViewModels.FaqContentCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">

--- a/Twelve/Areas/Admin/Views/Home/IndexContent.cshtml
+++ b/Twelve/Areas/Admin/Views/Home/IndexContent.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.IndexContent
+﻿@model ViewModels.IndexContentCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">

--- a/ViewModels/BlogViewModels.cs
+++ b/ViewModels/BlogViewModels.cs
@@ -28,6 +28,15 @@ namespace ViewModels
         [Display(Name = "توضیحات")]
         [Required(ErrorMessage = "لطفا {0} را وارد کنید")]
         public string Description { get; set; }
+        public string TitleEn { get; set; }
+        public string TitleAr { get; set; }
+        public string TitleUr { get; set; }
+        public string ShortDescriptionEn { get; set; }
+        public string ShortDescriptionAr { get; set; }
+        public string ShortDescriptionUr { get; set; }
+        public string DescriptionEn { get; set; }
+        public string DescriptionAr { get; set; }
+        public string DescriptionUr { get; set; }
         public string ImageName { get; set; }
         public string Source { get; set; }
         public string Tags { get; set; }
@@ -54,6 +63,21 @@ namespace ViewModels
         public List<BlogCommentViewModel> Comments { get; set; }
         public PaginationViewModel Pagination { get; set; }
         public double PageCount { get; set; }
+    }
+
+    public class BlogGroupCrudViewModel
+    {
+        public int BlogGroupId { get; set; }
+
+        [Display(Name = "عنوان")]
+        [Required(ErrorMessage = "لطفا {0} را وارد کنید")]
+        public string GroupName { get; set; }
+
+        public string GroupNameEn { get; set; }
+        public string GroupNameAr { get; set; }
+        public string GroupNameUr { get; set; }
+
+        public int? ParentId { get; set; }
     }
     public class BlogGroupNameViewModel
     {

--- a/ViewModels/FaqsViewModel.cs
+++ b/ViewModels/FaqsViewModel.cs
@@ -11,9 +11,42 @@ namespace ViewModels
         public int FaqID { get; set; }
         public string Question { get; set; }
         public string Answer { get; set; }
+        public string QuestionEn { get; set; }
+        public string QuestionAr { get; set; }
+        public string QuestionUr { get; set; }
+        public string AnswerEn { get; set; }
+        public string AnswerAr { get; set; }
+        public string AnswerUr { get; set; }
         public bool IsMain { get; set; }
         public List<FaqsGroupsItemViewModel> Groups { get; set; }
         public List<int> SelectedGroups { get; set; }
+    }
+
+    public class FaqGroupCrudViewModel
+    {
+        public int FaqGroupId { get; set; }
+        public string GroupName { get; set; }
+        public string GroupNameEn { get; set; }
+        public string GroupNameAr { get; set; }
+        public string GroupNameUr { get; set; }
+        public int? ParentId { get; set; }
+    }
+
+    public class FaqContentCrudViewModel
+    {
+        public int FaqContentId { get; set; }
+        public string FaqContentTitle { get; set; }
+        public string FaqContentSubTitle { get; set; }
+        public string FaqContentDescription { get; set; }
+        public string FaqContentTitleEn { get; set; }
+        public string FaqContentTitleAr { get; set; }
+        public string FaqContentTitleUr { get; set; }
+        public string FaqContentSubTitleEn { get; set; }
+        public string FaqContentSubTitleAr { get; set; }
+        public string FaqContentSubTitleUr { get; set; }
+        public string FaqContentDescriptionEn { get; set; }
+        public string FaqContentDescriptionAr { get; set; }
+        public string FaqContentDescriptionUr { get; set; }
     }
 
     public class FaqsPageDataViewModel

--- a/ViewModels/FeaturesViewModel.cs
+++ b/ViewModels/FeaturesViewModel.cs
@@ -53,4 +53,57 @@ namespace ViewModels
         public string Demo { get; set; }
         public bool IsBig { get; set; }
     }
+
+    public class FeatureCrudViewModel
+    {
+        public int FeatureId { get; set; }
+        public string Title { get; set; }
+        public string ShortDescription { get; set; }
+        public string FirstDescription { get; set; }
+        public string FirstArticleTitle { get; set; }
+        public string FirstArticleDescription { get; set; }
+        public string SecondArticleTitle { get; set; }
+        public string SecondArticleDescription { get; set; }
+        public string TitleEn { get; set; }
+        public string TitleAr { get; set; }
+        public string TitleUr { get; set; }
+        public string ShortDescriptionEn { get; set; }
+        public string ShortDescriptionAr { get; set; }
+        public string ShortDescriptionUr { get; set; }
+        public string FirstDescriptionEn { get; set; }
+        public string FirstDescriptionAr { get; set; }
+        public string FirstDescriptionUr { get; set; }
+        public string FirstArticleTitleEn { get; set; }
+        public string FirstArticleTitleAr { get; set; }
+        public string FirstArticleTitleUr { get; set; }
+        public string FirstArticleDescriptionEn { get; set; }
+        public string FirstArticleDescriptionAr { get; set; }
+        public string FirstArticleDescriptionUr { get; set; }
+        public string SecondArticleTitleEn { get; set; }
+        public string SecondArticleTitleAr { get; set; }
+        public string SecondArticleTitleUr { get; set; }
+        public string SecondArticleDescriptionEn { get; set; }
+        public string SecondArticleDescriptionAr { get; set; }
+        public string SecondArticleDescriptionUr { get; set; }
+        public string ImageName { get; set; }
+        public string AnimateFilename { get; set; }
+        public string FirstArticleImage { get; set; }
+        public string SecondArticleImage { get; set; }
+        public string IntroduceImageName { get; set; }
+    }
+
+    public class FeatureItemCrudViewModel
+    {
+        public int FeaturesItemId { get; set; }
+        public int FeatureId { get; set; }
+        public string Title { get; set; }
+        public string ShortDescription { get; set; }
+        public string TitleEn { get; set; }
+        public string TitleAr { get; set; }
+        public string TitleUr { get; set; }
+        public string ShortDescriptionEn { get; set; }
+        public string ShortDescriptionAr { get; set; }
+        public string ShortDescriptionUr { get; set; }
+        public string ImageName { get; set; }
+    }
 }

--- a/ViewModels/SiteGeneralViewModels.cs
+++ b/ViewModels/SiteGeneralViewModels.cs
@@ -8,6 +8,93 @@ using System.Threading.Tasks;
 namespace ViewModels
 {
 
+    public class IndexContentCrudViewModel
+    {
+        public int IndexContentId { get; set; }
+        public string AboutTitle { get; set; }
+        public string AboutSubTitle { get; set; }
+        public string AboutDescription { get; set; }
+        public string FeatureTitle { get; set; }
+        public string FeatureSubTitle { get; set; }
+        public string FeatureDescription { get; set; }
+        public string FaqTitle { get; set; }
+        public string FaqSubTitle { get; set; }
+        public string FaqDescription { get; set; }
+        public string AboutTitleEn { get; set; }
+        public string AboutTitleAr { get; set; }
+        public string AboutTitleUr { get; set; }
+        public string AboutSubTitleEn { get; set; }
+        public string AboutSubTitleAr { get; set; }
+        public string AboutSubTitleUr { get; set; }
+        public string AboutDescriptionEn { get; set; }
+        public string AboutDescriptionAr { get; set; }
+        public string AboutDescriptionUr { get; set; }
+        public string FeatureTitleEn { get; set; }
+        public string FeatureTitleAr { get; set; }
+        public string FeatureTitleUr { get; set; }
+        public string FeatureSubTitleEn { get; set; }
+        public string FeatureSubTitleAr { get; set; }
+        public string FeatureSubTitleUr { get; set; }
+        public string FeatureDescriptionEn { get; set; }
+        public string FeatureDescriptionAr { get; set; }
+        public string FeatureDescriptionUr { get; set; }
+        public string FaqTitleEn { get; set; }
+        public string FaqTitleAr { get; set; }
+        public string FaqTitleUr { get; set; }
+        public string FaqSubTitleEn { get; set; }
+        public string FaqSubTitleAr { get; set; }
+        public string FaqSubTitleUr { get; set; }
+        public string FaqDescriptionEn { get; set; }
+        public string FaqDescriptionAr { get; set; }
+        public string FaqDescriptionUr { get; set; }
+    }
+
+    public class ContactUsContentCrudViewModel
+    {
+        public int ContactUsContentId { get; set; }
+        public string FirstSubTitle { get; set; }
+        public string FirstTitle { get; set; }
+        public string FristDescription { get; set; }
+        public string SecondSubTitle { get; set; }
+        public string SecondTitle { get; set; }
+        public string SecondDescription { get; set; }
+        public string FirstSubTitleEn { get; set; }
+        public string FirstSubTitleAr { get; set; }
+        public string FirstSubTitleUr { get; set; }
+        public string FirstTitleEn { get; set; }
+        public string FirstTitleAr { get; set; }
+        public string FirstTitleUr { get; set; }
+        public string FristDescriptionEn { get; set; }
+        public string FristDescriptionAr { get; set; }
+        public string FristDescriptionUr { get; set; }
+        public string SecondSubTitleEn { get; set; }
+        public string SecondSubTitleAr { get; set; }
+        public string SecondSubTitleUr { get; set; }
+        public string SecondTitleEn { get; set; }
+        public string SecondTitleAr { get; set; }
+        public string SecondTitleUr { get; set; }
+        public string SecondDescriptionEn { get; set; }
+        public string SecondDescriptionAr { get; set; }
+        public string SecondDescriptionUr { get; set; }
+    }
+
+    public class FeaturesContentCrudViewModel
+    {
+        public int FeatureContentId { get; set; }
+        public string FeaturesTitle { get; set; }
+        public string FeatruesSubTitle { get; set; }
+        public string FeaturesDescription { get; set; }
+        public string FeaturesTitleEn { get; set; }
+        public string FeaturesTitleAr { get; set; }
+        public string FeaturesTitleUr { get; set; }
+        public string FeatruesSubTitleEn { get; set; }
+        public string FeatruesSubTitleAr { get; set; }
+        public string FeatruesSubTitleUr { get; set; }
+        public string FeaturesDescriptionEn { get; set; }
+        public string FeaturesDescriptionAr { get; set; }
+        public string FeaturesDescriptionUr { get; set; }
+    }
+
     public class SeoTagsViewModel
     {
         public int BlogID { get; set; }


### PR DESCRIPTION
## Summary
- Add FAQ group translation view models and CRUD repository methods
- Localize FAQ group admin forms with FA/EN/AR/UR tabs
- Introduce site content view models and save translated index/contact/FAQ content

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_688e95d3bfc48327bc0f6b96509ee7ca