### PR TITLE
Add multilingual support for blog, FAQ, and features editing

### DIFF
--- a/Services/Repository/IAboutUsArticlesRepository.cs
+++ b/Services/Repository/IAboutUsArticlesRepository.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ViewModels;
 
 namespace Services
 {
@@ -12,8 +13,10 @@ namespace Services
     {
         public List<AboutUsArticle> GetAboutUsArticles();
         public AboutUsArticle GetByID(int aboutUsArticleID);
-        public bool Create(AboutUsArticle aboutUsArticle , IFormFile ImageName);
-        public bool Update(AboutUsArticle aboutUsArticle , IFormFile ImageName);
+        public AboutUsArticleCrudViewModel GetForEdit(int aboutUsArticleID);
+        public bool Create(AboutUsArticleCrudViewModel aboutUsArticle, IFormFile ImageName);
+        public bool Update(AboutUsArticleCrudViewModel aboutUsArticle, IFormFile ImageName);
         public bool Delete(AboutUsArticle aboutUsArticle);
+        public void SaveTranslations(AboutUsArticleCrudViewModel aboutUsArticle);
     }
 }

--- a/Services/Repository/IAboutUsItemsRepository.cs
+++ b/Services/Repository/IAboutUsItemsRepository.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ViewModels;
 
 namespace Services
 {
@@ -12,8 +13,10 @@ namespace Services
     {
         public List<AboutUsItem> GetAboutUsItems();
         public AboutUsItem GetByID(int itemID);
-        public bool Create(AboutUsItem item , IFormFile ImageName);
-        public bool Update(AboutUsItem item , IFormFile ImageName);
+        public AboutUsItemCrudViewModel GetForEdit(int itemID);
+        public bool Create(AboutUsItemCrudViewModel item, IFormFile ImageName);
+        public bool Update(AboutUsItemCrudViewModel item, IFormFile ImageName);
         public bool Delete(AboutUsItem item);
+        public void SaveTranslations(AboutUsItemCrudViewModel item);
     }
 }

--- a/Services/Repository/IAboutUsSightRepository.cs
+++ b/Services/Repository/IAboutUsSightRepository.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ViewModels;
 
 namespace Services
 {
@@ -13,8 +14,10 @@ namespace Services
         public List<AboutUsSight> GetAboutUsSights();
 
         public AboutUsSight GetByID(int aboutUsSightID);
-        public bool Create(AboutUsSight sight , IFormFile ImageName);
-        public bool Update(AboutUsSight sight , IFormFile ImageName);
+        public AboutUsSightCrudViewModel GetForEdit(int aboutUsSightID);
+        public bool Create(AboutUsSightCrudViewModel sight, IFormFile ImageName);
+        public bool Update(AboutUsSightCrudViewModel sight, IFormFile ImageName);
         public bool Delete(AboutUsSight sight);
+        public void SaveTranslations(AboutUsSightCrudViewModel sight);
     }
 }

--- a/Services/Repository/IAdvertisementsRepository.cs
+++ b/Services/Repository/IAdvertisementsRepository.cs
@@ -17,6 +17,8 @@ namespace Services
         public bool Update(Advertisement advertisement , IFormFile ImageName);
         public bool Delete(Advertisement advertisement);
         public Advertisement GetByID(int adsID);
+        public AdvertisementCrudViewModel GetForEdit(int adsID);
         public List<AdvertisementsItemViewModel> GetAdvertisements();
+        public void SaveTranslations(AdvertisementCrudViewModel advertisement);
     }
 }

--- a/Services/Repository/IBlogGroupsRepository.cs
+++ b/Services/Repository/IBlogGroupsRepository.cs
@@ -15,6 +15,8 @@ namespace Services
         public bool Delete(BlogGroup blogGroup);
         public BlogGroup GetByID(int id);
         public List<BlogGroupNameViewModel> GetAllGroups();
+        public BlogGroupCrudViewModel GetForEdit(int id);
+        public void SaveTranslations(BlogGroupCrudViewModel group);
 
         public string GetBlogGroupNameByBlogID(int BlogID);
     }

--- a/Services/Repository/IBlogRepository.cs
+++ b/Services/Repository/IBlogRepository.cs
@@ -46,6 +46,7 @@ namespace Services
         public bool Delete(int ID);
         public BlogCrudViewModel GetModelForCreate();
         public BlogCrudViewModel GetByID(int BlogID);
+        public void SaveTranslations(BlogCrudViewModel blog);
         public BlogCommentsPageDataViewModel GetNewsComments(string q = "", int PageID = 1);
         public BlogCommentsPageDataViewModel GetNewsConfirmComments(string q = "", int PageID = 1);
         public BlogCommentsPageDataViewModel GetNewsAnswerComments(string q = "", int PageID = 1);

--- a/Services/Repository/ICallInfoRepository.cs
+++ b/Services/Repository/ICallInfoRepository.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using System.Text;
 using System.Threading.Tasks;
 using DataLayer;
+using ViewModels;
 
 namespace Services
 {
@@ -17,5 +18,7 @@ namespace Services
         public bool Update(DataLayer.CallInfo callInfo ,IFormFile ImageName );
         public bool Create(DataLayer.CallInfo callInfo ,IFormFile ImageName );
         public List<DataLayer.CallInfo> GetCallInfoes();
+        public CallInfoCrudViewModel GetForEdit(int infoID);
+        public void SaveTranslations(CallInfoCrudViewModel callInfo);
     }
 }

--- a/Services/Repository/IFaqsRepository.cs
+++ b/Services/Repository/IFaqsRepository.cs
@@ -11,18 +11,22 @@ namespace Services
     public interface IFaqsRepository : IDisposable
     {
         public FaqContent GetFaqContent();
-        public bool UpdateFaqContent(FaqContent content);
+        public FaqContentCrudViewModel GetFaqContentForEdit();
+        public bool UpdateFaqContent(FaqContentCrudViewModel content);
         public bool CreateGroup(FaqGroup faqGroup);
         public bool UpdateGroup(FaqGroup faqGroup);
         public bool DeleteGroup(FaqGroup faqGroup);
 
         public FaqGroup GetGroupByID(int id);
+        public FaqGroupCrudViewModel GetGroupForEdit(int id);
+        public void SaveGroupTranslations(FaqGroupCrudViewModel group);
 
         public FaqsCrudViewModel GetModelForCreate();
         public FaqsCrudViewModel GetByID(int FaqID);
         public bool Create(FaqsCrudViewModel faqs);
         public bool Update(FaqsCrudViewModel faqs);
         public bool Delete(int FaqID);
+        public void SaveTranslations(FaqsCrudViewModel faqs);
 
         public PaginationViewModel GetPagination(double PageCount, int PageID = 1);
 

--- a/Services/Repository/IFeaturesRepository.cs
+++ b/Services/Repository/IFeaturesRepository.cs
@@ -12,16 +12,19 @@ namespace Services
     public interface IFeaturesRepository : IDisposable
     {
         public FeaturesContent GetFeaturesContent();
-        public bool UpdateFeaturesContent(FeaturesContent content);
+        public FeaturesContentCrudViewModel GetFeaturesContentForEdit();
+        public bool UpdateFeaturesContent(FeaturesContentCrudViewModel content);
 
         public IntroduceAppViewModel GetIntroduceApp();
         public List<BlogItemViewModel> GetRelatedNews(int FeatureID);
 
         public Feature GetByID(int id);
+        public FeatureCrudViewModel GetForEdit(int id);
         public bool Create(Feature feature , IFormFile ImageName , IFormFile AnimateFile , IFormFile FirstArticleImage , IFormFile SecondArticleImage, IFormFile IntroduceImage);
         public bool Update(Feature feature , IFormFile ImageName , IFormFile AnimateFile , IFormFile FirstArticleImage , IFormFile SecondArticleImage , IFormFile IntroduceImage);
         public bool Update(Feature feature , IFormFile IntroduceImage);
         public bool Delete(Feature feature);
+        public void SaveTranslations(FeatureCrudViewModel feature);
         public AdminFeaturesPageDataViewModel GetAdminFeatures(string q = "" , int PageID =1);
         public PaginationViewModel GetPagination(double PageCount, int PageID = 1);
 
@@ -31,9 +34,11 @@ namespace Services
         public List<Feature> GetFeatureIntroduces();
 
         public FeatureItem GetItemByID(int ItemID);
+        public FeatureItemCrudViewModel GetItemForEdit(int ItemID);
         public bool CreateItem(FeatureItem featureItem , IFormFile formFile);
         public bool UpdateItem(FeatureItem featureItem , IFormFile formFile);
         public bool DeleteItem(FeatureItem featureItem);
+        public void SaveItemTranslations(FeatureItemCrudViewModel item);
 
         public List<FeatureIconsViewModel> GetFeaturesIcons(int featureID);
     }

--- a/Services/Repository/IIntroducesRepository.cs
+++ b/Services/Repository/IIntroducesRepository.cs
@@ -17,5 +17,6 @@ namespace Services
 
         public IntroduceCrudViewModel GetModelForCreate();
         public IntroduceCrudViewModel GetByID(int introduceID);
+        public void SaveTranslations(IntroduceCrudViewModel model);
     }
 }

--- a/Services/Repository/ISiteRepository.cs
+++ b/Services/Repository/ISiteRepository.cs
@@ -12,11 +12,12 @@ namespace Services
     public interface ISiteRepository : IDisposable
     {
         #region Contents
-        public IndexContent GetIndexContent();
-        public ContactUsContent GetContactUsContent();
-        public bool UpdateIndexContent(IndexContent content);
-        public bool UpdateAboutUsContent(AboutUsContent content , IFormFile imageProduct , IFormFile downloadProduct);
-        public bool UpdateContactUsContent(ContactUsContent content);
+        public IndexContentCrudViewModel GetIndexContent();
+        public ContactUsContentCrudViewModel GetContactUsContent();
+        public AboutUsContentCrudViewModel GetAboutUsContentForEdit();
+        public bool UpdateIndexContent(IndexContentCrudViewModel content);
+        public bool UpdateAboutUsContent(AboutUsContentCrudViewModel content, IFormFile imageProduct, IFormFile downloadProduct);
+        public bool UpdateContactUsContent(ContactUsContentCrudViewModel content);
 
         #endregion Contents
         public ContentItemViewModel GetContactUsSecondDescription();

--- a/Services/Repository/ISlidersRepository.cs
+++ b/Services/Repository/ISlidersRepository.cs
@@ -15,6 +15,7 @@ namespace Services
         public bool Update(Slider slider , IFormFile ImageName);
         public bool Create(Slider slider, IFormFile ImageName);
         public Slider GetByID(int SliderID);
+        public SliderCrudViewModel GetForEdit(int sliderId);
         public List<Slider> GetSliders(int GroupID);
         public List<SliderGroup> GetSliderGroups();
         public IndexSliderViewModel GetIndexHeader();
@@ -23,5 +24,6 @@ namespace Services
         public List<IndexSliderItemViewModel> GetContactUsSlider();
         public List<IndexSliderItemViewModel> GetBlogSlider();
         public List<IndexSliderItemViewModel> GetQoutesSlider();
+        public void SaveTranslations(SliderCrudViewModel slider);
     }
 }

--- a/Services/Services/AboutUsArticlesRepository.cs
+++ b/Services/Services/AboutUsArticlesRepository.cs
@@ -5,13 +5,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ViewModels;
 
 namespace Services
 {
     public class AboutUsArticlesRepository : IAboutUsArticlesRepository
     {
         TwelveDbContext db = new TwelveDbContext();
-        public bool Create(AboutUsArticle aboutUsArticle, IFormFile ImageName)
+        public bool Create(AboutUsArticleCrudViewModel aboutUsArticle, IFormFile ImageName)
         {
             try
             {
@@ -19,17 +20,25 @@ namespace Services
                 {
                     return false;
                 }
-                aboutUsArticle.ImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(ImageName.FileName);
-                string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", aboutUsArticle.ImageName);
+                var entity = new AboutUsArticle
+                {
+                    Title = aboutUsArticle.Title,
+                    SubTitle = aboutUsArticle.SubTitle,
+                    Description = aboutUsArticle.Description
+                };
+                entity.ImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(ImageName.FileName);
+                string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", entity.ImageName);
                 using (var stream = new FileStream(fullPath, FileMode.Create))
                 {
                     ImageName.CopyTo(stream);
                 }
-                db.AboutUsArticles.Add(aboutUsArticle);
+                db.AboutUsArticles.Add(entity);
                 db.SaveChanges();
+                aboutUsArticle.AboutUsArticleId = entity.AboutUsArticleId;
+                aboutUsArticle.ImageName = entity.ImageName;
                 return true;
             }
-            catch 
+            catch
             {
                 return false;
             }
@@ -71,32 +80,89 @@ namespace Services
             return item;
         }
 
-        public bool Update(AboutUsArticle aboutUsArticle, IFormFile ImageName)
+        public AboutUsArticleCrudViewModel GetForEdit(int aboutUsArticleID)
+        {
+            var item = db.AboutUsArticles.Find(aboutUsArticleID);
+            var translations = db.EntityTranslations.Where(t => t.EntityName == nameof(AboutUsArticle) && t.EntityId == aboutUsArticleID).ToList();
+            return new AboutUsArticleCrudViewModel
+            {
+                AboutUsArticleId = item.AboutUsArticleId,
+                Title = item.Title,
+                SubTitle = item.SubTitle,
+                Description = item.Description,
+                ImageName = item.ImageName,
+                TitleEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsArticle.Title) && t.Culture == "en")?.Value,
+                TitleAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsArticle.Title) && t.Culture == "ar")?.Value,
+                TitleUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsArticle.Title) && t.Culture == "ur")?.Value,
+                SubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsArticle.SubTitle) && t.Culture == "en")?.Value,
+                SubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsArticle.SubTitle) && t.Culture == "ar")?.Value,
+                SubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsArticle.SubTitle) && t.Culture == "ur")?.Value,
+                DescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsArticle.Description) && t.Culture == "en")?.Value,
+                DescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsArticle.Description) && t.Culture == "ar")?.Value,
+                DescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsArticle.Description) && t.Culture == "ur")?.Value
+            };
+        }
+
+        public bool Update(AboutUsArticleCrudViewModel aboutUsArticle, IFormFile ImageName)
         {
             try
             {
+                var entity = db.AboutUsArticles.Find(aboutUsArticle.AboutUsArticleId);
+                entity.Title = aboutUsArticle.Title;
+                entity.SubTitle = aboutUsArticle.SubTitle;
+                entity.Description = aboutUsArticle.Description;
                 if (ImageName != null)
                 {
-                    string imagePath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", aboutUsArticle.ImageName);
-
+                    string imagePath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", entity.ImageName);
                     System.IO.File.Delete(imagePath);
-
-                    aboutUsArticle.ImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(ImageName.FileName);
-                    string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", aboutUsArticle.ImageName);
+                    entity.ImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(ImageName.FileName);
+                    string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", entity.ImageName);
                     using (var stream = new FileStream(fullPath, FileMode.Create))
                     {
                         ImageName.CopyTo(stream);
                     }
-
                 }
-                db.AboutUsArticles.Update(aboutUsArticle);
+                db.AboutUsArticles.Update(entity);
                 db.SaveChanges();
+                aboutUsArticle.ImageName = entity.ImageName;
                 return true;
             }
-            catch 
+            catch
             {
                 return false;
             }
+        }
+
+        public void SaveTranslations(AboutUsArticleCrudViewModel aboutUsArticle)
+        {
+            SaveTranslation(nameof(AboutUsArticle), aboutUsArticle.AboutUsArticleId, nameof(AboutUsArticle.Title), "en", aboutUsArticle.TitleEn);
+            SaveTranslation(nameof(AboutUsArticle), aboutUsArticle.AboutUsArticleId, nameof(AboutUsArticle.Title), "ar", aboutUsArticle.TitleAr);
+            SaveTranslation(nameof(AboutUsArticle), aboutUsArticle.AboutUsArticleId, nameof(AboutUsArticle.Title), "ur", aboutUsArticle.TitleUr);
+            SaveTranslation(nameof(AboutUsArticle), aboutUsArticle.AboutUsArticleId, nameof(AboutUsArticle.SubTitle), "en", aboutUsArticle.SubTitleEn);
+            SaveTranslation(nameof(AboutUsArticle), aboutUsArticle.AboutUsArticleId, nameof(AboutUsArticle.SubTitle), "ar", aboutUsArticle.SubTitleAr);
+            SaveTranslation(nameof(AboutUsArticle), aboutUsArticle.AboutUsArticleId, nameof(AboutUsArticle.SubTitle), "ur", aboutUsArticle.SubTitleUr);
+            SaveTranslation(nameof(AboutUsArticle), aboutUsArticle.AboutUsArticleId, nameof(AboutUsArticle.Description), "en", aboutUsArticle.DescriptionEn);
+            SaveTranslation(nameof(AboutUsArticle), aboutUsArticle.AboutUsArticleId, nameof(AboutUsArticle.Description), "ar", aboutUsArticle.DescriptionAr);
+            SaveTranslation(nameof(AboutUsArticle), aboutUsArticle.AboutUsArticleId, nameof(AboutUsArticle.Description), "ur", aboutUsArticle.DescriptionUr);
+        }
+
+        private void SaveTranslation(string entityName, int entityId, string property, string culture, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return;
+            var tr = db.EntityTranslations.FirstOrDefault(t => t.EntityName == entityName && t.EntityId == entityId && t.Property == property && t.Culture == culture);
+            if (tr == null)
+            {
+                tr = new EntityTranslation
+                {
+                    EntityName = entityName,
+                    EntityId = entityId,
+                    Property = property,
+                    Culture = culture
+                };
+                db.EntityTranslations.Add(tr);
+            }
+            tr.Value = value;
+            db.SaveChanges();
         }
     }
 }

--- a/Services/Services/AboutUsItemsRepository.cs
+++ b/Services/Services/AboutUsItemsRepository.cs
@@ -5,13 +5,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ViewModels;
 
 namespace Services
 {
     public class AboutUsItemsRepository : IAboutUsItemsRepository
     {
         TwelveDbContext db = new TwelveDbContext();
-        public bool Create(AboutUsItem item, IFormFile ImageName)
+        public bool Create(AboutUsItemCrudViewModel item, IFormFile ImageName)
         {
             try
             {
@@ -19,17 +20,24 @@ namespace Services
                 {
                     return false;
                 }
-                item.ImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(ImageName.FileName);
-                string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", item.ImageName);
+                var entity = new AboutUsItem
+                {
+                    ItemTitle = item.ItemTitle,
+                    ItemDescription = item.ItemDescription
+                };
+                entity.ImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(ImageName.FileName);
+                string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", entity.ImageName);
                 using (var stream = new FileStream(fullPath, FileMode.Create))
                 {
                     ImageName.CopyTo(stream);
                 }
-                db.AboutUsItems.Add(item);
+                db.AboutUsItems.Add(entity);
                 db.SaveChanges();
+                item.AboutUsItemId = entity.AboutUsItemId;
+                item.ImageName = entity.ImageName;
                 return true;
             }
-            catch 
+            catch
             {
                 return false;
             }
@@ -71,32 +79,81 @@ namespace Services
             return item;
         }
 
-        public bool Update(AboutUsItem item, IFormFile ImageName)
+        public AboutUsItemCrudViewModel GetForEdit(int itemID)
+        {
+            var item = db.AboutUsItems.Find(itemID);
+            var translations = db.EntityTranslations.Where(t => t.EntityName == nameof(AboutUsItem) && t.EntityId == itemID).ToList();
+            return new AboutUsItemCrudViewModel
+            {
+                AboutUsItemId = item.AboutUsItemId,
+                ItemTitle = item.ItemTitle,
+                ItemDescription = item.ItemDescription,
+                ImageName = item.ImageName,
+                ItemTitleEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsItem.ItemTitle) && t.Culture == "en")?.Value,
+                ItemTitleAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsItem.ItemTitle) && t.Culture == "ar")?.Value,
+                ItemTitleUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsItem.ItemTitle) && t.Culture == "ur")?.Value,
+                ItemDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsItem.ItemDescription) && t.Culture == "en")?.Value,
+                ItemDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsItem.ItemDescription) && t.Culture == "ar")?.Value,
+                ItemDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsItem.ItemDescription) && t.Culture == "ur")?.Value
+            };
+        }
+
+        public bool Update(AboutUsItemCrudViewModel item, IFormFile ImageName)
         {
             try
             {
+                var entity = db.AboutUsItems.Find(item.AboutUsItemId);
+                entity.ItemTitle = item.ItemTitle;
+                entity.ItemDescription = item.ItemDescription;
                 if (ImageName != null)
                 {
-                    string imagePath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", item.ImageName);
-
+                    string imagePath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", entity.ImageName);
                     System.IO.File.Delete(imagePath);
-
-                    item.ImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(ImageName.FileName);
-                    string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", item.ImageName);
+                    entity.ImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(ImageName.FileName);
+                    string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", entity.ImageName);
                     using (var stream = new FileStream(fullPath, FileMode.Create))
                     {
                         ImageName.CopyTo(stream);
                     }
-
                 }
-                db.AboutUsItems.Update(item);
+                db.AboutUsItems.Update(entity);
                 db.SaveChanges();
+                item.ImageName = entity.ImageName;
                 return true;
             }
-            catch 
+            catch
             {
                 return false;
             }
+        }
+
+        public void SaveTranslations(AboutUsItemCrudViewModel item)
+        {
+            SaveTranslation(nameof(AboutUsItem), item.AboutUsItemId, nameof(AboutUsItem.ItemTitle), "en", item.ItemTitleEn);
+            SaveTranslation(nameof(AboutUsItem), item.AboutUsItemId, nameof(AboutUsItem.ItemTitle), "ar", item.ItemTitleAr);
+            SaveTranslation(nameof(AboutUsItem), item.AboutUsItemId, nameof(AboutUsItem.ItemTitle), "ur", item.ItemTitleUr);
+            SaveTranslation(nameof(AboutUsItem), item.AboutUsItemId, nameof(AboutUsItem.ItemDescription), "en", item.ItemDescriptionEn);
+            SaveTranslation(nameof(AboutUsItem), item.AboutUsItemId, nameof(AboutUsItem.ItemDescription), "ar", item.ItemDescriptionAr);
+            SaveTranslation(nameof(AboutUsItem), item.AboutUsItemId, nameof(AboutUsItem.ItemDescription), "ur", item.ItemDescriptionUr);
+        }
+
+        private void SaveTranslation(string entityName, int entityId, string property, string culture, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return;
+            var tr = db.EntityTranslations.FirstOrDefault(t => t.EntityName == entityName && t.EntityId == entityId && t.Property == property && t.Culture == culture);
+            if (tr == null)
+            {
+                tr = new EntityTranslation
+                {
+                    EntityName = entityName,
+                    EntityId = entityId,
+                    Property = property,
+                    Culture = culture
+                };
+                db.EntityTranslations.Add(tr);
+            }
+            tr.Value = value;
+            db.SaveChanges();
         }
     }
 }

--- a/Services/Services/AboutUsSightRepository.cs
+++ b/Services/Services/AboutUsSightRepository.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Text;
 using System.Threading.Tasks;
+using ViewModels;
 
 namespace Services
 {
@@ -13,7 +14,7 @@ namespace Services
     {
         TwelveDbContext db = new TwelveDbContext();
 
-        public bool Create(AboutUsSight sight , IFormFile ImageName)
+        public bool Create(AboutUsSightCrudViewModel sight, IFormFile ImageName)
         {
             try
             {
@@ -21,17 +22,24 @@ namespace Services
                 {
                     return false;
                 }
-                sight.ImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(ImageName.FileName);
-                string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", sight.ImageName);
+                var entity = new AboutUsSight
+                {
+                    SightTitle = sight.SightTitle,
+                    SightDescription = sight.SightDescription
+                };
+                entity.ImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(ImageName.FileName);
+                string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", entity.ImageName);
                 using (var stream = new FileStream(fullPath, FileMode.Create))
                 {
                     ImageName.CopyTo(stream);
                 }
-                db.AboutUsSights.Add(sight);
+                db.AboutUsSights.Add(entity);
                 db.SaveChanges();
+                sight.AboutUsSightId = entity.AboutUsSightId;
+                sight.ImageName = entity.ImageName;
                 return true;
             }
-            catch 
+            catch
             {
                 return false;
             }
@@ -73,32 +81,81 @@ namespace Services
             return item;
         }
 
-        public bool Update(AboutUsSight sight , IFormFile ImageName)
+        public AboutUsSightCrudViewModel GetForEdit(int aboutUsSightID)
+        {
+            var item = db.AboutUsSights.Find(aboutUsSightID);
+            var translations = db.EntityTranslations.Where(t => t.EntityName == nameof(AboutUsSight) && t.EntityId == aboutUsSightID).ToList();
+            return new AboutUsSightCrudViewModel
+            {
+                AboutUsSightId = item.AboutUsSightId,
+                SightTitle = item.SightTitle,
+                SightDescription = item.SightDescription,
+                ImageName = item.ImageName,
+                SightTitleEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsSight.SightTitle) && t.Culture == "en")?.Value,
+                SightTitleAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsSight.SightTitle) && t.Culture == "ar")?.Value,
+                SightTitleUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsSight.SightTitle) && t.Culture == "ur")?.Value,
+                SightDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsSight.SightDescription) && t.Culture == "en")?.Value,
+                SightDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsSight.SightDescription) && t.Culture == "ar")?.Value,
+                SightDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsSight.SightDescription) && t.Culture == "ur")?.Value
+            };
+        }
+
+        public bool Update(AboutUsSightCrudViewModel sight, IFormFile ImageName)
         {
             try
             {
+                var entity = db.AboutUsSights.Find(sight.AboutUsSightId);
+                entity.SightTitle = sight.SightTitle;
+                entity.SightDescription = sight.SightDescription;
                 if (ImageName != null)
                 {
-                    string imagePath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", sight.ImageName);
-
+                    string imagePath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", entity.ImageName);
                     System.IO.File.Delete(imagePath);
-
-                    sight.ImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(ImageName.FileName);
-                    string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", sight.ImageName);
+                    entity.ImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(ImageName.FileName);
+                    string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", entity.ImageName);
                     using (var stream = new FileStream(fullPath, FileMode.Create))
                     {
                         ImageName.CopyTo(stream);
                     }
-
                 }
-                db.AboutUsSights.Update(sight);
+                db.AboutUsSights.Update(entity);
                 db.SaveChanges();
+                sight.ImageName = entity.ImageName;
                 return true;
             }
-            catch 
+            catch
             {
                 return false;
             }
+        }
+
+        public void SaveTranslations(AboutUsSightCrudViewModel sight)
+        {
+            SaveTranslation(nameof(AboutUsSight), sight.AboutUsSightId, nameof(AboutUsSight.SightTitle), "en", sight.SightTitleEn);
+            SaveTranslation(nameof(AboutUsSight), sight.AboutUsSightId, nameof(AboutUsSight.SightTitle), "ar", sight.SightTitleAr);
+            SaveTranslation(nameof(AboutUsSight), sight.AboutUsSightId, nameof(AboutUsSight.SightTitle), "ur", sight.SightTitleUr);
+            SaveTranslation(nameof(AboutUsSight), sight.AboutUsSightId, nameof(AboutUsSight.SightDescription), "en", sight.SightDescriptionEn);
+            SaveTranslation(nameof(AboutUsSight), sight.AboutUsSightId, nameof(AboutUsSight.SightDescription), "ar", sight.SightDescriptionAr);
+            SaveTranslation(nameof(AboutUsSight), sight.AboutUsSightId, nameof(AboutUsSight.SightDescription), "ur", sight.SightDescriptionUr);
+        }
+
+        private void SaveTranslation(string entityName, int entityId, string property, string culture, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return;
+            var tr = db.EntityTranslations.FirstOrDefault(t => t.EntityName == entityName && t.EntityId == entityId && t.Property == property && t.Culture == culture);
+            if (tr == null)
+            {
+                tr = new EntityTranslation
+                {
+                    EntityName = entityName,
+                    EntityId = entityId,
+                    Property = property,
+                    Culture = culture
+                };
+                db.EntityTranslations.Add(tr);
+            }
+            tr.Value = value;
+            db.SaveChanges();
         }
     }
 }

--- a/Services/Services/AdvertisementsRepository.cs
+++ b/Services/Services/AdvertisementsRepository.cs
@@ -22,7 +22,6 @@ namespace Services
                 {
                     return false;
                 }
-                advertisement.Title = "Ads";
                 advertisement.ImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(ImageName.FileName);
                 string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Ads", advertisement.ImageName);
                 using (var stream = new FileStream(fullPath, FileMode.Create))
@@ -67,11 +66,12 @@ namespace Services
             List<AdvertisementsItemViewModel> model = new List<AdvertisementsItemViewModel>();
             foreach (var item in items)
             {
-                model.Add(new AdvertisementsItemViewModel() 
+                model.Add(new AdvertisementsItemViewModel()
                 {
                     AdvertisementID = item.AdvertisementId,
                     ImageName = item.ImageName,
-                    Link = item.Link
+                    Link = item.Link,
+                    Title = item.Title
                 });
             }
             return model;
@@ -89,6 +89,24 @@ namespace Services
             var item = db.Advertisements.Find(adsID);
             item.ApplyTranslation(db);
             return item;
+        }
+
+        public AdvertisementCrudViewModel GetForEdit(int adsID)
+        {
+            var ad = db.Advertisements.Find(adsID);
+            var model = new AdvertisementCrudViewModel
+            {
+                AdvertisementId = ad.AdvertisementId,
+                Title = ad.Title,
+                Link = ad.Link,
+                IsBanner = ad.IsBanner,
+                ImageName = ad.ImageName
+            };
+            var tr = db.EntityTranslations.ToList();
+            model.TitleEn = tr.FirstOrDefault(t => t.EntityName == nameof(Advertisement) && t.EntityId == adsID && t.Property == nameof(Advertisement.Title) && t.Culture == "en")?.Value;
+            model.TitleAr = tr.FirstOrDefault(t => t.EntityName == nameof(Advertisement) && t.EntityId == adsID && t.Property == nameof(Advertisement.Title) && t.Culture == "ar")?.Value;
+            model.TitleUr = tr.FirstOrDefault(t => t.EntityName == nameof(Advertisement) && t.EntityId == adsID && t.Property == nameof(Advertisement.Title) && t.Culture == "ur")?.Value;
+            return model;
         }
 
         public List<Advertisement> GetLittleAds()
@@ -125,6 +143,39 @@ namespace Services
             catch
             {
                 return false;
+            }
+        }
+
+        public void SaveTranslations(AdvertisementCrudViewModel advertisement)
+        {
+            SaveTranslation(nameof(Advertisement), advertisement.AdvertisementId, nameof(Advertisement.Title), "en", advertisement.TitleEn);
+            SaveTranslation(nameof(Advertisement), advertisement.AdvertisementId, nameof(Advertisement.Title), "ar", advertisement.TitleAr);
+            SaveTranslation(nameof(Advertisement), advertisement.AdvertisementId, nameof(Advertisement.Title), "ur", advertisement.TitleUr);
+        }
+
+        private void SaveTranslation(string entityName, int entityId, string property, string culture, string value)
+        {
+            var tr = db.EntityTranslations.FirstOrDefault(t => t.EntityName == entityName && t.EntityId == entityId && t.Property == property && t.Culture == culture);
+            if (tr == null)
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    db.EntityTranslations.Add(new EntityTranslation
+                    {
+                        EntityName = entityName,
+                        EntityId = entityId,
+                        Property = property,
+                        Culture = culture,
+                        Value = value
+                    });
+                    db.SaveChanges();
+                }
+            }
+            else
+            {
+                tr.Value = value;
+                db.EntityTranslations.Update(tr);
+                db.SaveChanges();
             }
         }
     }

--- a/Services/Services/BlogGroupsRepository.cs
+++ b/Services/Services/BlogGroupsRepository.cs
@@ -63,6 +63,30 @@ namespace Services
             return groups;
         }
 
+        public BlogGroupCrudViewModel GetForEdit(int id)
+        {
+            var group = db.BlogGroups.Find(id);
+            var translations = db.EntityTranslations
+                .Where(t => t.EntityName == nameof(BlogGroup) && t.EntityId == id)
+                .ToList();
+            return new BlogGroupCrudViewModel
+            {
+                BlogGroupId = group.BlogGroupId,
+                GroupName = group.GroupName,
+                ParentId = group.ParentId,
+                GroupNameEn = translations.FirstOrDefault(t => t.Property == "GroupName" && t.Culture == "en")?.Value,
+                GroupNameAr = translations.FirstOrDefault(t => t.Property == "GroupName" && t.Culture == "ar")?.Value,
+                GroupNameUr = translations.FirstOrDefault(t => t.Property == "GroupName" && t.Culture == "ur")?.Value
+            };
+        }
+
+        public void SaveTranslations(BlogGroupCrudViewModel group)
+        {
+            SaveTranslation(nameof(BlogGroup), group.BlogGroupId, "GroupName", "en", group.GroupNameEn);
+            SaveTranslation(nameof(BlogGroup), group.BlogGroupId, "GroupName", "ar", group.GroupNameAr);
+            SaveTranslation(nameof(BlogGroup), group.BlogGroupId, "GroupName", "ur", group.GroupNameUr);
+        }
+
 
         public string GetBlogGroupNameByBlogID(int BlogID)
         {
@@ -91,6 +115,25 @@ namespace Services
             {
                 return false;
             }
+        }
+
+        private void SaveTranslation(string entityName, int entityId, string property, string culture, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return;
+            var tr = db.EntityTranslations.FirstOrDefault(t => t.EntityName == entityName && t.EntityId == entityId && t.Property == property && t.Culture == culture);
+            if (tr == null)
+            {
+                tr = new EntityTranslation
+                {
+                    EntityName = entityName,
+                    EntityId = entityId,
+                    Property = property,
+                    Culture = culture
+                };
+                db.EntityTranslations.Add(tr);
+            }
+            tr.Value = value;
+            db.SaveChanges();
         }
     }
 }

--- a/Services/Services/BlogRepository.cs
+++ b/Services/Services/BlogRepository.cs
@@ -628,14 +628,16 @@ namespace Services
                 var posts = db.Blogs.OrderByDescending(b => b.CreateDate).Skip(skip).Take(take).ToList();
                 foreach (var item in posts)
                 {
-                    List<string> groupName = db.SelectedBlogGroups.Where(b => b.BlogId == item.BlogId).Include(b => b.BlogGroup).Select(b => b.BlogGroup.GroupName).ToList();
+                    var tr = db.BlogTranslations.FirstOrDefault(t => t.BlogId == item.BlogId && t.Language == CurrentCulture);
+                    var groups = db.SelectedBlogGroups.Where(b => b.BlogId == item.BlogId).Include(b => b.BlogGroup).ToList();
+                    groups.ForEach(g => g.BlogGroup.ApplyTranslation(db));
                     blogPosts.Posts.Add(new BlogPostsItemViewModel()
                     {
                         BlogID = item.BlogId,
-                        Title = item.Title,
+                        Title = tr?.Title ?? item.Title,
                         CreateDate = DateConvertor.ToShamsi(item.CreateDate),
                         View = item.PostView,
-                        GroupName = string.Join(" ، ", groupName)
+                        GroupName = string.Join(" ، ", groups.Select(g => g.BlogGroup.GroupName))
                     });
                 }
                 double pCount = Convert.ToDouble(Convert.ToDouble(db.Blogs.ToList().Count()) / Convert.ToDouble(take));
@@ -648,14 +650,16 @@ namespace Services
                 var posts = db.Blogs.Where(b => b.Title.Contains(q)).OrderByDescending(b => b.CreateDate).Skip(skip).Take(take).ToList();
                 foreach (var item in posts)
                 {
-                    List<string> groupName = db.SelectedBlogGroups.Where(b => b.BlogId == item.BlogId).Include(b => b.BlogGroup).Select(b => b.BlogGroup.GroupName).ToList();
+                    var tr = db.BlogTranslations.FirstOrDefault(t => t.BlogId == item.BlogId && t.Language == CurrentCulture);
+                    var groups = db.SelectedBlogGroups.Where(b => b.BlogId == item.BlogId).Include(b => b.BlogGroup).ToList();
+                    groups.ForEach(g => g.BlogGroup.ApplyTranslation(db));
                     blogPosts.Posts.Add(new BlogPostsItemViewModel()
                     {
                         BlogID = item.BlogId,
-                        Title = item.Title,
+                        Title = tr?.Title ?? item.Title,
                         CreateDate = DateConvertor.ToShamsi(item.CreateDate),
                         View = item.PostView,
-                        GroupName = string.Join(" ، ", groupName)
+                        GroupName = string.Join(" ، ", groups.Select(g => g.BlogGroup.GroupName))
                     });
                 }
                 double pCount = Convert.ToDouble(Convert.ToDouble(db.Blogs.Where(b => b.Title.Contains(q)).ToList().Count()) / Convert.ToDouble(take));
@@ -1053,6 +1057,7 @@ namespace Services
                 };
                 db.Blogs.Add(model);
                 db.SaveChanges();
+                blog.BlogID = model.BlogId;
 
                 var tags = blog.Tags.Split('،').ToList();
 
@@ -1171,6 +1176,7 @@ namespace Services
             BlogCrudViewModel model = new BlogCrudViewModel();
             model.Groups = new List<BlogGroupNameViewModel>();
             var items = db.BlogGroups.ToList();
+            items.ApplyTranslations(db);
             foreach (var item in items)
             {
                 model.Groups.Add(new BlogGroupNameViewModel()
@@ -1199,7 +1205,30 @@ namespace Services
                 SelectedGroups = db.SelectedBlogGroups.Where(s => s.BlogId == BlogID).Select(s => s.BlogGroupId).ToList()
             };
 
+            var trEn = db.BlogTranslations.FirstOrDefault(t => t.BlogId == BlogID && t.Language == "en");
+            var trAr = db.BlogTranslations.FirstOrDefault(t => t.BlogId == BlogID && t.Language == "ar");
+            var trUr = db.BlogTranslations.FirstOrDefault(t => t.BlogId == BlogID && t.Language == "ur");
+            if (trEn != null)
+            {
+                model.TitleEn = trEn.Title;
+                model.ShortDescriptionEn = trEn.ShortDescription;
+                model.DescriptionEn = trEn.Description;
+            }
+            if (trAr != null)
+            {
+                model.TitleAr = trAr.Title;
+                model.ShortDescriptionAr = trAr.ShortDescription;
+                model.DescriptionAr = trAr.Description;
+            }
+            if (trUr != null)
+            {
+                model.TitleUr = trUr.Title;
+                model.ShortDescriptionUr = trUr.ShortDescription;
+                model.DescriptionUr = trUr.Description;
+            }
+
             var groups = db.BlogGroups.ToList();
+            groups.ApplyTranslations(db);
             model.Groups = new List<BlogGroupNameViewModel>();
             foreach (var item in groups)
             {
@@ -1210,6 +1239,31 @@ namespace Services
                 });
             }
             return model;
+        }
+
+        public void SaveTranslations(BlogCrudViewModel blog)
+        {
+            SaveBlogTranslation(blog.BlogID, "en", blog.TitleEn, blog.ShortDescriptionEn, blog.DescriptionEn);
+            SaveBlogTranslation(blog.BlogID, "ar", blog.TitleAr, blog.ShortDescriptionAr, blog.DescriptionAr);
+            SaveBlogTranslation(blog.BlogID, "ur", blog.TitleUr, blog.ShortDescriptionUr, blog.DescriptionUr);
+        }
+
+        private void SaveBlogTranslation(int blogId, string lang, string title, string shortDescription, string description)
+        {
+            if (string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(shortDescription) && string.IsNullOrWhiteSpace(description))
+            {
+                return;
+            }
+            var tr = db.BlogTranslations.FirstOrDefault(t => t.BlogId == blogId && t.Language == lang);
+            if (tr == null)
+            {
+                tr = new BlogTranslation { BlogId = blogId, Language = lang };
+                db.BlogTranslations.Add(tr);
+            }
+            tr.Title = title ?? "";
+            tr.ShortDescription = shortDescription ?? "";
+            tr.Description = description ?? "";
+            db.SaveChanges();
         }
 
         #region NewsCrud

--- a/Services/Services/CallInfoRepository.cs
+++ b/Services/Services/CallInfoRepository.cs
@@ -6,6 +6,7 @@ using System.Dynamic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ViewModels;
 
 namespace Services
 {
@@ -65,6 +66,30 @@ namespace Services
             return item;
         }
 
+        public CallInfoCrudViewModel GetForEdit(int infoID)
+        {
+            var call = db.CallInfoes.Find(infoID);
+            var model = new CallInfoCrudViewModel
+            {
+                CallInfoId = call.CallInfoId,
+                Title = call.Title,
+                ShortDescription = call.ShortDescription,
+                Description = call.Description,
+                ImageName = call.ImageName
+            };
+            var tr = db.EntityTranslations.ToList();
+            model.TitleEn = tr.FirstOrDefault(t => t.EntityName == nameof(CallInfo) && t.EntityId == infoID && t.Property == nameof(CallInfo.Title) && t.Culture == "en")?.Value;
+            model.TitleAr = tr.FirstOrDefault(t => t.EntityName == nameof(CallInfo) && t.EntityId == infoID && t.Property == nameof(CallInfo.Title) && t.Culture == "ar")?.Value;
+            model.TitleUr = tr.FirstOrDefault(t => t.EntityName == nameof(CallInfo) && t.EntityId == infoID && t.Property == nameof(CallInfo.Title) && t.Culture == "ur")?.Value;
+            model.ShortDescriptionEn = tr.FirstOrDefault(t => t.EntityName == nameof(CallInfo) && t.EntityId == infoID && t.Property == nameof(CallInfo.ShortDescription) && t.Culture == "en")?.Value;
+            model.ShortDescriptionAr = tr.FirstOrDefault(t => t.EntityName == nameof(CallInfo) && t.EntityId == infoID && t.Property == nameof(CallInfo.ShortDescription) && t.Culture == "ar")?.Value;
+            model.ShortDescriptionUr = tr.FirstOrDefault(t => t.EntityName == nameof(CallInfo) && t.EntityId == infoID && t.Property == nameof(CallInfo.ShortDescription) && t.Culture == "ur")?.Value;
+            model.DescriptionEn = tr.FirstOrDefault(t => t.EntityName == nameof(CallInfo) && t.EntityId == infoID && t.Property == nameof(CallInfo.Description) && t.Culture == "en")?.Value;
+            model.DescriptionAr = tr.FirstOrDefault(t => t.EntityName == nameof(CallInfo) && t.EntityId == infoID && t.Property == nameof(CallInfo.Description) && t.Culture == "ar")?.Value;
+            model.DescriptionUr = tr.FirstOrDefault(t => t.EntityName == nameof(CallInfo) && t.EntityId == infoID && t.Property == nameof(CallInfo.Description) && t.Culture == "ur")?.Value;
+            return model;
+        }
+
         public List<DataLayer.CallInfo> GetCallInfoes()
         {
             var items = db.CallInfoes.ToList();
@@ -106,7 +131,46 @@ namespace Services
             {
                 return false;
             }
-            
+
+        }
+
+        public void SaveTranslations(CallInfoCrudViewModel callInfo)
+        {
+            SaveTranslation(nameof(CallInfo), callInfo.CallInfoId, nameof(CallInfo.Title), "en", callInfo.TitleEn);
+            SaveTranslation(nameof(CallInfo), callInfo.CallInfoId, nameof(CallInfo.Title), "ar", callInfo.TitleAr);
+            SaveTranslation(nameof(CallInfo), callInfo.CallInfoId, nameof(CallInfo.Title), "ur", callInfo.TitleUr);
+            SaveTranslation(nameof(CallInfo), callInfo.CallInfoId, nameof(CallInfo.ShortDescription), "en", callInfo.ShortDescriptionEn);
+            SaveTranslation(nameof(CallInfo), callInfo.CallInfoId, nameof(CallInfo.ShortDescription), "ar", callInfo.ShortDescriptionAr);
+            SaveTranslation(nameof(CallInfo), callInfo.CallInfoId, nameof(CallInfo.ShortDescription), "ur", callInfo.ShortDescriptionUr);
+            SaveTranslation(nameof(CallInfo), callInfo.CallInfoId, nameof(CallInfo.Description), "en", callInfo.DescriptionEn);
+            SaveTranslation(nameof(CallInfo), callInfo.CallInfoId, nameof(CallInfo.Description), "ar", callInfo.DescriptionAr);
+            SaveTranslation(nameof(CallInfo), callInfo.CallInfoId, nameof(CallInfo.Description), "ur", callInfo.DescriptionUr);
+        }
+
+        private void SaveTranslation(string entityName, int entityId, string property, string culture, string value)
+        {
+            var tr = db.EntityTranslations.FirstOrDefault(t => t.EntityName == entityName && t.EntityId == entityId && t.Property == property && t.Culture == culture);
+            if (tr == null)
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    db.EntityTranslations.Add(new EntityTranslation
+                    {
+                        EntityName = entityName,
+                        EntityId = entityId,
+                        Property = property,
+                        Culture = culture,
+                        Value = value
+                    });
+                    db.SaveChanges();
+                }
+            }
+            else
+            {
+                tr.Value = value;
+                db.EntityTranslations.Update(tr);
+                db.SaveChanges();
+            }
         }
     }
 }

--- a/Services/Services/FaqsRepository.cs
+++ b/Services/Services/FaqsRepository.cs
@@ -21,17 +21,20 @@ namespace Services
 
         public string GetFaqGroupNameByID(int GroupID)
         {
-            return db.FaqGroups.Find(GroupID).GroupName;
+            var item = db.FaqGroups.Find(GroupID);
+            item.ApplyTranslation(db);
+            return item.GroupName;
         }
 
         public List<FaqsGroupsItemViewModel> GetFaqGroups()
         {
             var items = db.FaqGroups.ToList();
+            items.ApplyTranslations(db);
             List<FaqsGroupsItemViewModel> model = new List<FaqsGroupsItemViewModel>();
 
             foreach (var item in items)
             {
-                model.Add(new FaqsGroupsItemViewModel 
+                model.Add(new FaqsGroupsItemViewModel
                 {
                     GroupID = item.FaqGroupId,
                     GroupName = item.GroupName
@@ -84,13 +87,15 @@ namespace Services
                 var faqs = db.Faqs.Skip(skip).Take(take).ToList();
                 foreach (var item in faqs)
                 {
-                    List<string> groups = db.SelectedFaqGroups.Where(g => g.FaqId == item.FaqId).Select(f => f.FaqGroup.GroupName).ToList();
-                    model.Faqs.Add(new FaqsItemViewModel() 
+                    var tr = db.FaqTranslations.FirstOrDefault(t => t.FaqId == item.FaqId && t.Language == CurrentCulture);
+                    var groups = db.SelectedFaqGroups.Where(g => g.FaqId == item.FaqId).Select(f => f.FaqGroup).ToList();
+                    groups.ApplyTranslations(db);
+                    model.Faqs.Add(new FaqsItemViewModel()
                     {
                         FaqID = item.FaqId,
-                        Answer = item.Answer,
-                        Question = item.Question,
-                        GroupName = string.Join(" ، ", groups)
+                        Answer = tr?.Answer ?? item.Answer,
+                        Question = tr?.Question ?? item.Question,
+                        GroupName = string.Join(" ، ", groups.Select(g => g.GroupName))
                     });
                 }
                 double pCount = Convert.ToDouble(Convert.ToDouble(db.Faqs.ToList().Count()) / Convert.ToDouble(take));
@@ -103,13 +108,15 @@ namespace Services
                 var faqs = db.Faqs.Where(f => f.Question.Contains(q) || f.Answer.Contains(q)).Skip(skip).Take(take).ToList();
                 foreach (var item in faqs)
                 {
-                    List<string> groups = db.SelectedFaqGroups.Where(g => g.FaqId == item.FaqId).Select(f => f.FaqGroup.GroupName).ToList();
+                    var tr = db.FaqTranslations.FirstOrDefault(t => t.FaqId == item.FaqId && t.Language == CurrentCulture);
+                    var groups = db.SelectedFaqGroups.Where(g => g.FaqId == item.FaqId).Select(f => f.FaqGroup).ToList();
+                    groups.ApplyTranslations(db);
                     model.Faqs.Add(new FaqsItemViewModel()
                     {
                         FaqID = item.FaqId,
-                        Answer = item.Answer,
-                        Question = item.Question,
-                        GroupName = string.Join(" ، ", groups)
+                        Answer = tr?.Answer ?? item.Answer,
+                        Question = tr?.Question ?? item.Question,
+                        GroupName = string.Join(" ، ", groups.Select(g => g.GroupName))
                     });
                 }
                 double pCount = Convert.ToDouble(Convert.ToDouble(db.Faqs.Where(f => f.Question.Contains(q) || f.Answer.Contains(q)).ToList().Count()) / Convert.ToDouble(take));
@@ -165,6 +172,24 @@ namespace Services
                 Question = faq.Question,
                 IsMain = faq.IsMain
             };
+            var trEn = db.FaqTranslations.FirstOrDefault(t => t.FaqId == FaqID && t.Language == "en");
+            var trAr = db.FaqTranslations.FirstOrDefault(t => t.FaqId == FaqID && t.Language == "ar");
+            var trUr = db.FaqTranslations.FirstOrDefault(t => t.FaqId == FaqID && t.Language == "ur");
+            if (trEn != null)
+            {
+                model.QuestionEn = trEn.Question;
+                model.AnswerEn = trEn.Answer;
+            }
+            if (trAr != null)
+            {
+                model.QuestionAr = trAr.Question;
+                model.AnswerAr = trAr.Answer;
+            }
+            if (trUr != null)
+            {
+                model.QuestionUr = trUr.Question;
+                model.AnswerUr = trUr.Answer;
+            }
             var groups = db.FaqGroups.ToList();
             model.Groups = new List<FaqsGroupsItemViewModel>();
             foreach (var group in groups)
@@ -178,6 +203,30 @@ namespace Services
             var selectedGroups = db.SelectedFaqGroups.Where(f => f.FaqId == FaqID).Select(f => f.FaqGroupId).ToList();
             model.SelectedGroups = selectedGroups;
             return model;
+        }
+
+        public void SaveTranslations(FaqsCrudViewModel faqs)
+        {
+            SaveFaqTranslation(faqs.FaqID, "en", faqs.QuestionEn, faqs.AnswerEn);
+            SaveFaqTranslation(faqs.FaqID, "ar", faqs.QuestionAr, faqs.AnswerAr);
+            SaveFaqTranslation(faqs.FaqID, "ur", faqs.QuestionUr, faqs.AnswerUr);
+        }
+
+        private void SaveFaqTranslation(int faqId, string lang, string question, string answer)
+        {
+            if (string.IsNullOrWhiteSpace(question) && string.IsNullOrWhiteSpace(answer))
+            {
+                return;
+            }
+            var tr = db.FaqTranslations.FirstOrDefault(t => t.FaqId == faqId && t.Language == lang);
+            if (tr == null)
+            {
+                tr = new FaqTranslation { FaqId = faqId, Language = lang };
+                db.FaqTranslations.Add(tr);
+            }
+            tr.Question = question ?? "";
+            tr.Answer = answer ?? "";
+            db.SaveChanges();
         }
 
         public bool Create(FaqsCrudViewModel faqs)
@@ -196,6 +245,7 @@ namespace Services
                 };
                 db.Faqs.Add(faq);
                 db.SaveChanges();
+                faqs.FaqID = faq.FaqId;
                 foreach (var item in faqs.SelectedGroups)
                 {
                     var selected = new SelectedFaqGroup() { FaqId = faq.FaqId , FaqGroupId = item };
@@ -329,23 +379,101 @@ namespace Services
             return db.FaqGroups.Find(id);
         }
 
-        public FaqContent GetFaqContent()
+        public FaqGroupCrudViewModel GetGroupForEdit(int id)
         {
-            return db.FaqContents.FirstOrDefault();
+            var group = db.FaqGroups.Find(id);
+            var translations = db.EntityTranslations.Where(t => t.EntityName == nameof(FaqGroup) && t.EntityId == id).ToList();
+            return new FaqGroupCrudViewModel
+            {
+                FaqGroupId = group.FaqGroupId,
+                GroupName = group.GroupName,
+                ParentId = group.ParentId,
+                GroupNameEn = translations.FirstOrDefault(t => t.Property == nameof(FaqGroup.GroupName) && t.Culture == "en")?.Value,
+                GroupNameAr = translations.FirstOrDefault(t => t.Property == nameof(FaqGroup.GroupName) && t.Culture == "ar")?.Value,
+                GroupNameUr = translations.FirstOrDefault(t => t.Property == nameof(FaqGroup.GroupName) && t.Culture == "ur")?.Value
+            };
         }
 
-        public bool UpdateFaqContent(FaqContent content )
+        public FaqContent GetFaqContent()
+        {
+            var item = db.FaqContents.FirstOrDefault();
+            item.ApplyTranslation(db);
+            return item;
+        }
+
+        public FaqContentCrudViewModel GetFaqContentForEdit()
+        {
+            var item = db.FaqContents.FirstOrDefault();
+            var translations = db.EntityTranslations.Where(t => t.EntityName == nameof(FaqContent) && t.EntityId == item.FaqContentId).ToList();
+            return new FaqContentCrudViewModel
+            {
+                FaqContentId = item.FaqContentId,
+                FaqContentTitle = item.FaqContentTitle,
+                FaqContentSubTitle = item.FaqContentSubTitle,
+                FaqContentDescription = item.FaqContentDescription,
+                FaqContentTitleEn = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentTitle) && t.Culture == "en")?.Value,
+                FaqContentTitleAr = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentTitle) && t.Culture == "ar")?.Value,
+                FaqContentTitleUr = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentTitle) && t.Culture == "ur")?.Value,
+                FaqContentSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentSubTitle) && t.Culture == "en")?.Value,
+                FaqContentSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentSubTitle) && t.Culture == "ar")?.Value,
+                FaqContentSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentSubTitle) && t.Culture == "ur")?.Value,
+                FaqContentDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentDescription) && t.Culture == "en")?.Value,
+                FaqContentDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentDescription) && t.Culture == "ar")?.Value,
+                FaqContentDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(FaqContent.FaqContentDescription) && t.Culture == "ur")?.Value
+            };
+        }
+
+        public bool UpdateFaqContent(FaqContentCrudViewModel content)
         {
             try
             {
-                db.FaqContents.Update(content);
+                var entity = db.FaqContents.Find(content.FaqContentId);
+                entity.FaqContentTitle = content.FaqContentTitle;
+                entity.FaqContentSubTitle = content.FaqContentSubTitle;
+                entity.FaqContentDescription = content.FaqContentDescription;
+                db.FaqContents.Update(entity);
                 db.SaveChanges();
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentTitle), "en", content.FaqContentTitleEn);
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentTitle), "ar", content.FaqContentTitleAr);
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentTitle), "ur", content.FaqContentTitleUr);
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentSubTitle), "en", content.FaqContentSubTitleEn);
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentSubTitle), "ar", content.FaqContentSubTitleAr);
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentSubTitle), "ur", content.FaqContentSubTitleUr);
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentDescription), "en", content.FaqContentDescriptionEn);
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentDescription), "ar", content.FaqContentDescriptionAr);
+                SaveTranslation(nameof(FaqContent), entity.FaqContentId, nameof(FaqContent.FaqContentDescription), "ur", content.FaqContentDescriptionUr);
                 return true;
             }
-            catch 
+            catch
             {
                 return false;
             }
+        }
+
+        public void SaveGroupTranslations(FaqGroupCrudViewModel group)
+        {
+            SaveTranslation(nameof(FaqGroup), group.FaqGroupId, nameof(FaqGroup.GroupName), "en", group.GroupNameEn);
+            SaveTranslation(nameof(FaqGroup), group.FaqGroupId, nameof(FaqGroup.GroupName), "ar", group.GroupNameAr);
+            SaveTranslation(nameof(FaqGroup), group.FaqGroupId, nameof(FaqGroup.GroupName), "ur", group.GroupNameUr);
+        }
+
+        private void SaveTranslation(string entityName, int entityId, string property, string culture, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return;
+            var tr = db.EntityTranslations.FirstOrDefault(t => t.EntityName == entityName && t.EntityId == entityId && t.Property == property && t.Culture == culture);
+            if (tr == null)
+            {
+                tr = new EntityTranslation
+                {
+                    EntityName = entityName,
+                    EntityId = entityId,
+                    Property = property,
+                    Culture = culture
+                };
+                db.EntityTranslations.Add(tr);
+            }
+            tr.Value = value;
+            db.SaveChanges();
         }
     }
 }

--- a/Services/Services/FeaturesRepository.cs
+++ b/Services/Services/FeaturesRepository.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -180,6 +181,27 @@ namespace Services
             return item;
         }
 
+        public FeatureItemCrudViewModel GetItemForEdit(int ItemID)
+        {
+            var item = db.FeatureItems.Find(ItemID);
+            var model = new FeatureItemCrudViewModel
+            {
+                FeaturesItemId = item.FeaturesItemId,
+                FeatureId = item.FeatureId,
+                Title = item.Title,
+                ShortDescription = item.ShortDescription,
+                ImageName = item.ImageName
+            };
+            var tr = db.EntityTranslations.ToList();
+            model.TitleEn = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "Title" && t.Culture == "en")?.Value;
+            model.TitleAr = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "Title" && t.Culture == "ar")?.Value;
+            model.TitleUr = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "Title" && t.Culture == "ur")?.Value;
+            model.ShortDescriptionEn = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "ShortDescription" && t.Culture == "en")?.Value;
+            model.ShortDescriptionAr = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "ShortDescription" && t.Culture == "ar")?.Value;
+            model.ShortDescriptionUr = tr.FirstOrDefault(t => t.EntityName == "FeatureItem" && t.EntityId == ItemID && t.Property == "ShortDescription" && t.Culture == "ur")?.Value;
+            return model;
+        }
+
         public bool CreateItem(FeatureItem featureItem, IFormFile ImageName)
         {
             try
@@ -252,6 +274,16 @@ namespace Services
             }
         }
 
+        public void SaveItemTranslations(FeatureItemCrudViewModel item)
+        {
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "Title", "en", item.TitleEn);
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "Title", "ar", item.TitleAr);
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "Title", "ur", item.TitleUr);
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "ShortDescription", "en", item.ShortDescriptionEn);
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "ShortDescription", "ar", item.ShortDescriptionAr);
+            SaveTranslation("FeatureItem", item.FeaturesItemId, "ShortDescription", "ur", item.ShortDescriptionUr);
+        }
+
         public bool Create(Feature feature, IFormFile ImageName, IFormFile AnimateFile, IFormFile FirstArticleImage, IFormFile SecondArticleImage ,  IFormFile IntroduceImage)
         {
             try
@@ -309,6 +341,50 @@ namespace Services
         public Feature GetByID(int id)
         {
             return db.Features.Find(id);
+        }
+
+        public FeatureCrudViewModel GetForEdit(int id)
+        {
+            var feature = db.Features.Find(id);
+            var model = new FeatureCrudViewModel
+            {
+                FeatureId = feature.FeatureId,
+                Title = feature.Title,
+                ShortDescription = feature.ShortDescription,
+                FirstDescription = feature.FirstDescription,
+                FirstArticleTitle = feature.FirstArticleTitle,
+                FirstArticleDescription = feature.FirstArticleDescription,
+                SecondArticleTitle = feature.SecondArticleTitle,
+                SecondArticleDescription = feature.SecondArticleDescription,
+                ImageName = feature.ImageName,
+                AnimateFilename = feature.AnimateFilename,
+                FirstArticleImage = feature.FirstArticleImage,
+                SecondArticleImage = feature.SecondArticleImage,
+                IntroduceImageName = feature.IntroduceImageName
+            };
+            var tr = db.EntityTranslations.ToList();
+            model.TitleEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "Title" && t.Culture == "en")?.Value;
+            model.TitleAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "Title" && t.Culture == "ar")?.Value;
+            model.TitleUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "Title" && t.Culture == "ur")?.Value;
+            model.ShortDescriptionEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "ShortDescription" && t.Culture == "en")?.Value;
+            model.ShortDescriptionAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "ShortDescription" && t.Culture == "ar")?.Value;
+            model.ShortDescriptionUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "ShortDescription" && t.Culture == "ur")?.Value;
+            model.FirstDescriptionEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstDescription" && t.Culture == "en")?.Value;
+            model.FirstDescriptionAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstDescription" && t.Culture == "ar")?.Value;
+            model.FirstDescriptionUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstDescription" && t.Culture == "ur")?.Value;
+            model.FirstArticleTitleEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleTitle" && t.Culture == "en")?.Value;
+            model.FirstArticleTitleAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleTitle" && t.Culture == "ar")?.Value;
+            model.FirstArticleTitleUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleTitle" && t.Culture == "ur")?.Value;
+            model.FirstArticleDescriptionEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleDescription" && t.Culture == "en")?.Value;
+            model.FirstArticleDescriptionAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleDescription" && t.Culture == "ar")?.Value;
+            model.FirstArticleDescriptionUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "FirstArticleDescription" && t.Culture == "ur")?.Value;
+            model.SecondArticleTitleEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleTitle" && t.Culture == "en")?.Value;
+            model.SecondArticleTitleAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleTitle" && t.Culture == "ar")?.Value;
+            model.SecondArticleTitleUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleTitle" && t.Culture == "ur")?.Value;
+            model.SecondArticleDescriptionEn = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleDescription" && t.Culture == "en")?.Value;
+            model.SecondArticleDescriptionAr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleDescription" && t.Culture == "ar")?.Value;
+            model.SecondArticleDescriptionUr = tr.FirstOrDefault(t => t.EntityName == "Feature" && t.EntityId == id && t.Property == "SecondArticleDescription" && t.Culture == "ur")?.Value;
+            return model;
         }
 
         public bool Update(Feature feature, IFormFile ImageName, IFormFile AnimateFile, IFormFile FirstArticleImage, IFormFile SecondArticleImage, IFormFile IntroduceImage)
@@ -426,6 +502,31 @@ namespace Services
             }
         }
 
+        public void SaveTranslations(FeatureCrudViewModel feature)
+        {
+            SaveTranslation("Feature", feature.FeatureId, "Title", "en", feature.TitleEn);
+            SaveTranslation("Feature", feature.FeatureId, "Title", "ar", feature.TitleAr);
+            SaveTranslation("Feature", feature.FeatureId, "Title", "ur", feature.TitleUr);
+            SaveTranslation("Feature", feature.FeatureId, "ShortDescription", "en", feature.ShortDescriptionEn);
+            SaveTranslation("Feature", feature.FeatureId, "ShortDescription", "ar", feature.ShortDescriptionAr);
+            SaveTranslation("Feature", feature.FeatureId, "ShortDescription", "ur", feature.ShortDescriptionUr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstDescription", "en", feature.FirstDescriptionEn);
+            SaveTranslation("Feature", feature.FeatureId, "FirstDescription", "ar", feature.FirstDescriptionAr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstDescription", "ur", feature.FirstDescriptionUr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleTitle", "en", feature.FirstArticleTitleEn);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleTitle", "ar", feature.FirstArticleTitleAr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleTitle", "ur", feature.FirstArticleTitleUr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleDescription", "en", feature.FirstArticleDescriptionEn);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleDescription", "ar", feature.FirstArticleDescriptionAr);
+            SaveTranslation("Feature", feature.FeatureId, "FirstArticleDescription", "ur", feature.FirstArticleDescriptionUr);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleTitle", "en", feature.SecondArticleTitleEn);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleTitle", "ar", feature.SecondArticleTitleAr);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleTitle", "ur", feature.SecondArticleTitleUr);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleDescription", "en", feature.SecondArticleDescriptionEn);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleDescription", "ar", feature.SecondArticleDescriptionAr);
+            SaveTranslation("Feature", feature.FeatureId, "SecondArticleDescription", "ur", feature.SecondArticleDescriptionUr);
+        }
+
         public bool Delete(Feature feature)
         {
             try
@@ -521,18 +622,55 @@ namespace Services
 
         public FeaturesContent GetFeaturesContent()
         {
-            return db.FeaturesContents.FirstOrDefault();
+            var item = db.FeaturesContents.FirstOrDefault();
+            item.ApplyTranslation(db);
+            return item;
         }
 
-        public bool UpdateFeaturesContent(FeaturesContent content)
+        public FeaturesContentCrudViewModel GetFeaturesContentForEdit()
+        {
+            var item = db.FeaturesContents.FirstOrDefault();
+            var translations = db.EntityTranslations.Where(t => t.EntityName == nameof(FeaturesContent) && t.EntityId == item.FeatureContentId).ToList();
+            return new FeaturesContentCrudViewModel
+            {
+                FeatureContentId = item.FeatureContentId,
+                FeaturesTitle = item.FeaturesTitle,
+                FeatruesSubTitle = item.FeatruesSubTitle,
+                FeaturesDescription = item.FeaturesDescription,
+                FeaturesTitleEn = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeaturesTitle) && t.Culture == "en")?.Value,
+                FeaturesTitleAr = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeaturesTitle) && t.Culture == "ar")?.Value,
+                FeaturesTitleUr = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeaturesTitle) && t.Culture == "ur")?.Value,
+                FeatruesSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeatruesSubTitle) && t.Culture == "en")?.Value,
+                FeatruesSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeatruesSubTitle) && t.Culture == "ar")?.Value,
+                FeatruesSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeatruesSubTitle) && t.Culture == "ur")?.Value,
+                FeaturesDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeaturesDescription) && t.Culture == "en")?.Value,
+                FeaturesDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeaturesDescription) && t.Culture == "ar")?.Value,
+                FeaturesDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(FeaturesContent.FeaturesDescription) && t.Culture == "ur")?.Value
+            };
+        }
+
+        public bool UpdateFeaturesContent(FeaturesContentCrudViewModel content)
         {
             try
             {
-                db.FeaturesContents.Update(content);
+                var entity = db.FeaturesContents.Find(content.FeatureContentId);
+                entity.FeaturesTitle = content.FeaturesTitle;
+                entity.FeatruesSubTitle = content.FeatruesSubTitle;
+                entity.FeaturesDescription = content.FeaturesDescription;
+                db.FeaturesContents.Update(entity);
                 db.SaveChanges();
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeaturesTitle), "en", content.FeaturesTitleEn);
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeaturesTitle), "ar", content.FeaturesTitleAr);
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeaturesTitle), "ur", content.FeaturesTitleUr);
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeatruesSubTitle), "en", content.FeatruesSubTitleEn);
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeatruesSubTitle), "ar", content.FeatruesSubTitleAr);
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeatruesSubTitle), "ur", content.FeatruesSubTitleUr);
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeaturesDescription), "en", content.FeaturesDescriptionEn);
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeaturesDescription), "ar", content.FeaturesDescriptionAr);
+                SaveTranslation(nameof(FeaturesContent), entity.FeatureContentId, nameof(FeaturesContent.FeaturesDescription), "ur", content.FeaturesDescriptionUr);
                 return true;
             }
-            catch 
+            catch
             {
                 return false;
             }
@@ -543,6 +681,28 @@ namespace Services
             return db.Features.ToList();
         }
 
-        
+        private void SaveTranslation(string entityName, int entityId, string property, string culture, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return;
+            }
+            var tr = db.EntityTranslations.FirstOrDefault(t => t.EntityName == entityName && t.EntityId == entityId && t.Property == property && t.Culture == culture);
+            if (tr == null)
+            {
+                tr = new EntityTranslation
+                {
+                    EntityName = entityName,
+                    EntityId = entityId,
+                    Property = property,
+                    Culture = culture
+                };
+                db.EntityTranslations.Add(tr);
+            }
+            tr.Value = value;
+            db.SaveChanges();
+        }
+
+
     }
 }

--- a/Services/Services/IntroducesRepository.cs
+++ b/Services/Services/IntroducesRepository.cs
@@ -22,7 +22,7 @@ namespace Services
                 }
                 foreach (var featureID in model.SelectedFeature)
                 {
-                    Introduce introduce = new Introduce() 
+                    Introduce introduce = new Introduce()
                     {
                         IntroduceTitle = model.Title,
                         IntroduceText = model.Description,
@@ -30,10 +30,11 @@ namespace Services
                     };
                     db.Introduces.Add(introduce);
                     db.SaveChanges();
+                    model.IntroduceID = introduce.IntroduceId;
                 }
                 return true;
             }
-            catch 
+            catch
             {
                 return false;
             }
@@ -62,11 +63,18 @@ namespace Services
         public IntroduceCrudViewModel GetByID(int introduceID)
         {
             var introduce = db.Introduces.Find(introduceID);
-            introduce.ApplyTranslation(db);
+            var translations = db.EntityTranslations.Where(t => t.EntityName == nameof(Introduce) && t.EntityId == introduceID).ToList();
             IntroduceCrudViewModel model = new IntroduceCrudViewModel()
             {
+                IntroduceID = introduceID,
                 Title = introduce.IntroduceTitle,
                 Description = introduce.IntroduceText,
+                TitleEn = translations.FirstOrDefault(t => t.Property == nameof(Introduce.IntroduceTitle) && t.Culture == "en")?.Value,
+                TitleAr = translations.FirstOrDefault(t => t.Property == nameof(Introduce.IntroduceTitle) && t.Culture == "ar")?.Value,
+                TitleUr = translations.FirstOrDefault(t => t.Property == nameof(Introduce.IntroduceTitle) && t.Culture == "ur")?.Value,
+                DescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(Introduce.IntroduceText) && t.Culture == "en")?.Value,
+                DescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(Introduce.IntroduceText) && t.Culture == "ar")?.Value,
+                DescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(Introduce.IntroduceText) && t.Culture == "ur")?.Value
             };
             model.SelectedFeature = new List<int>();
             model.Features = new List<FeatureNameViewModel>();
@@ -139,6 +147,35 @@ namespace Services
             {
                 return false;
             }
+        }
+
+        public void SaveTranslations(IntroduceCrudViewModel model)
+        {
+            SaveTranslation(nameof(Introduce), model.IntroduceID, nameof(Introduce.IntroduceTitle), "en", model.TitleEn);
+            SaveTranslation(nameof(Introduce), model.IntroduceID, nameof(Introduce.IntroduceTitle), "ar", model.TitleAr);
+            SaveTranslation(nameof(Introduce), model.IntroduceID, nameof(Introduce.IntroduceTitle), "ur", model.TitleUr);
+            SaveTranslation(nameof(Introduce), model.IntroduceID, nameof(Introduce.IntroduceText), "en", model.DescriptionEn);
+            SaveTranslation(nameof(Introduce), model.IntroduceID, nameof(Introduce.IntroduceText), "ar", model.DescriptionAr);
+            SaveTranslation(nameof(Introduce), model.IntroduceID, nameof(Introduce.IntroduceText), "ur", model.DescriptionUr);
+        }
+
+        private void SaveTranslation(string entityName, int entityId, string property, string culture, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return;
+            var tr = db.EntityTranslations.FirstOrDefault(t => t.EntityName == entityName && t.EntityId == entityId && t.Property == property && t.Culture == culture);
+            if (tr == null)
+            {
+                tr = new EntityTranslation
+                {
+                    EntityName = entityName,
+                    EntityId = entityId,
+                    Property = property,
+                    Culture = culture
+                };
+                db.EntityTranslations.Add(tr);
+            }
+            tr.Value = value;
+            db.SaveChanges();
         }
     }
 }

--- a/Services/Services/LocalizationExtensions.cs
+++ b/Services/Services/LocalizationExtensions.cs
@@ -15,6 +15,10 @@ namespace Services
             var culture = CultureInfo.CurrentUICulture.Name;
             var entityName = typeof(T).Name;
             var idProp = typeof(T).GetProperties().FirstOrDefault(p => p.Name == entityName + "Id");
+            if (idProp == null)
+            {
+                idProp = typeof(T).GetProperties().FirstOrDefault(p => p.Name.EndsWith("Id", StringComparison.OrdinalIgnoreCase) && p.PropertyType == typeof(int));
+            }
             if (idProp == null) return;
             var id = (int)(idProp.GetValue(entity) ?? 0);
             var translations = db.EntityTranslations

--- a/Services/Services/SiteRepository.cs
+++ b/Services/Services/SiteRepository.cs
@@ -583,6 +583,74 @@ namespace Services
             return item;
         }
 
+        public AboutUsContentCrudViewModel GetAboutUsContentForEdit()
+        {
+            var item = db.AboutUsContents.FirstOrDefault();
+            var translations = db.EntityTranslations.Where(t => t.EntityName == nameof(AboutUsContent) && t.EntityId == item.AboutUsContentId).ToList();
+            return new AboutUsContentCrudViewModel
+            {
+                AboutUsContentId = item.AboutUsContentId,
+                SubTitle = item.SubTitle,
+                Title = item.Title,
+                Description = item.Description,
+                ImageName = item.ImageName,
+                SecondSubTitle = item.SecondSubTitle,
+                SecondTitle = item.SecondTitle,
+                SecondDescription = item.SecondDescription,
+                ThirdSubTitle = item.ThirdSubTitle,
+                ThirdTitle = item.ThirdTitle,
+                DownloadImageName = item.DownloadImageName,
+                ForthSubTitle = item.ForthSubTitle,
+                ForthTitle = item.ForthTitle,
+                ForthDescription = item.ForthDescription,
+                LogoTitle = item.LogoTitle,
+                LogoSubTitle = item.LogoSubTitle,
+                LogoDescription = item.LogoDescription,
+                SubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.SubTitle) && t.Culture == "en")?.Value,
+                SubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.SubTitle) && t.Culture == "ar")?.Value,
+                SubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.SubTitle) && t.Culture == "ur")?.Value,
+                TitleEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.Title) && t.Culture == "en")?.Value,
+                TitleAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.Title) && t.Culture == "ar")?.Value,
+                TitleUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.Title) && t.Culture == "ur")?.Value,
+                DescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.Description) && t.Culture == "en")?.Value,
+                DescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.Description) && t.Culture == "ar")?.Value,
+                DescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.Description) && t.Culture == "ur")?.Value,
+                SecondSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.SecondSubTitle) && t.Culture == "en")?.Value,
+                SecondSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.SecondSubTitle) && t.Culture == "ar")?.Value,
+                SecondSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.SecondSubTitle) && t.Culture == "ur")?.Value,
+                SecondTitleEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.SecondTitle) && t.Culture == "en")?.Value,
+                SecondTitleAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.SecondTitle) && t.Culture == "ar")?.Value,
+                SecondTitleUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.SecondTitle) && t.Culture == "ur")?.Value,
+                SecondDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.SecondDescription) && t.Culture == "en")?.Value,
+                SecondDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.SecondDescription) && t.Culture == "ar")?.Value,
+                SecondDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.SecondDescription) && t.Culture == "ur")?.Value,
+                ThirdSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.ThirdSubTitle) && t.Culture == "en")?.Value,
+                ThirdSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.ThirdSubTitle) && t.Culture == "ar")?.Value,
+                ThirdSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.ThirdSubTitle) && t.Culture == "ur")?.Value,
+                ThirdTitleEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.ThirdTitle) && t.Culture == "en")?.Value,
+                ThirdTitleAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.ThirdTitle) && t.Culture == "ar")?.Value,
+                ThirdTitleUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.ThirdTitle) && t.Culture == "ur")?.Value,
+                ForthSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.ForthSubTitle) && t.Culture == "en")?.Value,
+                ForthSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.ForthSubTitle) && t.Culture == "ar")?.Value,
+                ForthSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.ForthSubTitle) && t.Culture == "ur")?.Value,
+                ForthTitleEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.ForthTitle) && t.Culture == "en")?.Value,
+                ForthTitleAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.ForthTitle) && t.Culture == "ar")?.Value,
+                ForthTitleUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.ForthTitle) && t.Culture == "ur")?.Value,
+                ForthDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.ForthDescription) && t.Culture == "en")?.Value,
+                ForthDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.ForthDescription) && t.Culture == "ar")?.Value,
+                ForthDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.ForthDescription) && t.Culture == "ur")?.Value,
+                LogoTitleEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.LogoTitle) && t.Culture == "en")?.Value,
+                LogoTitleAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.LogoTitle) && t.Culture == "ar")?.Value,
+                LogoTitleUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.LogoTitle) && t.Culture == "ur")?.Value,
+                LogoSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.LogoSubTitle) && t.Culture == "en")?.Value,
+                LogoSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.LogoSubTitle) && t.Culture == "ar")?.Value,
+                LogoSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.LogoSubTitle) && t.Culture == "ur")?.Value,
+                LogoDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.LogoDescription) && t.Culture == "en")?.Value,
+                LogoDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.LogoDescription) && t.Culture == "ar")?.Value,
+                LogoDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(AboutUsContent.LogoDescription) && t.Culture == "ur")?.Value
+            };
+        }
+
         public List<AboutUsSight> GetAboutUsSights()
         {
             var items = db.AboutUsSights.ToList();
@@ -652,19 +720,95 @@ namespace Services
         }
 
         #region Contents
-        public IndexContent GetIndexContent()
+        public IndexContentCrudViewModel GetIndexContent()
         {
             var item = db.IndexContents.FirstOrDefault();
-            item.ApplyTranslation(db);
-            return item;
+            var translations = db.EntityTranslations.Where(t => t.EntityName == nameof(IndexContent) && t.EntityId == item.IndexContentId).ToList();
+            return new IndexContentCrudViewModel
+            {
+                IndexContentId = item.IndexContentId,
+                AboutTitle = item.AboutTitle,
+                AboutSubTitle = item.AboutSubTitle,
+                AboutDescription = item.AboutDescription,
+                FeatureTitle = item.FeatureTitle,
+                FeatureSubTitle = item.FeatureSubTitle,
+                FeatureDescription = item.FeatureDescription,
+                FaqTitle = item.FaqTitle,
+                FaqSubTitle = item.FaqSubTitle,
+                FaqDescription = item.FaqDescription,
+                AboutTitleEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutTitle) && t.Culture == "en")?.Value,
+                AboutTitleAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutTitle) && t.Culture == "ar")?.Value,
+                AboutTitleUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutTitle) && t.Culture == "ur")?.Value,
+                AboutSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutSubTitle) && t.Culture == "en")?.Value,
+                AboutSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutSubTitle) && t.Culture == "ar")?.Value,
+                AboutSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutSubTitle) && t.Culture == "ur")?.Value,
+                AboutDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutDescription) && t.Culture == "en")?.Value,
+                AboutDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutDescription) && t.Culture == "ar")?.Value,
+                AboutDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.AboutDescription) && t.Culture == "ur")?.Value,
+                FeatureTitleEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureTitle) && t.Culture == "en")?.Value,
+                FeatureTitleAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureTitle) && t.Culture == "ar")?.Value,
+                FeatureTitleUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureTitle) && t.Culture == "ur")?.Value,
+                FeatureSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureSubTitle) && t.Culture == "en")?.Value,
+                FeatureSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureSubTitle) && t.Culture == "ar")?.Value,
+                FeatureSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureSubTitle) && t.Culture == "ur")?.Value,
+                FeatureDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureDescription) && t.Culture == "en")?.Value,
+                FeatureDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureDescription) && t.Culture == "ar")?.Value,
+                FeatureDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FeatureDescription) && t.Culture == "ur")?.Value,
+                FaqTitleEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqTitle) && t.Culture == "en")?.Value,
+                FaqTitleAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqTitle) && t.Culture == "ar")?.Value,
+                FaqTitleUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqTitle) && t.Culture == "ur")?.Value,
+                FaqSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqSubTitle) && t.Culture == "en")?.Value,
+                FaqSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqSubTitle) && t.Culture == "ar")?.Value,
+                FaqSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqSubTitle) && t.Culture == "ur")?.Value,
+                FaqDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqDescription) && t.Culture == "en")?.Value,
+                FaqDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqDescription) && t.Culture == "ar")?.Value,
+                FaqDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(IndexContent.FaqDescription) && t.Culture == "ur")?.Value
+            };
         }
 
-        public bool UpdateIndexContent(IndexContent content)
+        public bool UpdateIndexContent(IndexContentCrudViewModel content)
         {
             try
             {
-                db.IndexContents.Update(content);
+                var entity = db.IndexContents.Find(content.IndexContentId);
+                entity.AboutTitle = content.AboutTitle;
+                entity.AboutSubTitle = content.AboutSubTitle;
+                entity.AboutDescription = content.AboutDescription;
+                entity.FeatureTitle = content.FeatureTitle;
+                entity.FeatureSubTitle = content.FeatureSubTitle;
+                entity.FeatureDescription = content.FeatureDescription;
+                entity.FaqTitle = content.FaqTitle;
+                entity.FaqSubTitle = content.FaqSubTitle;
+                entity.FaqDescription = content.FaqDescription;
+                db.IndexContents.Update(entity);
                 db.SaveChanges();
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutTitle), "en", content.AboutTitleEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutTitle), "ar", content.AboutTitleAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutTitle), "ur", content.AboutTitleUr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutSubTitle), "en", content.AboutSubTitleEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutSubTitle), "ar", content.AboutSubTitleAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutSubTitle), "ur", content.AboutSubTitleUr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutDescription), "en", content.AboutDescriptionEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutDescription), "ar", content.AboutDescriptionAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.AboutDescription), "ur", content.AboutDescriptionUr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureTitle), "en", content.FeatureTitleEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureTitle), "ar", content.FeatureTitleAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureTitle), "ur", content.FeatureTitleUr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureSubTitle), "en", content.FeatureSubTitleEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureSubTitle), "ar", content.FeatureSubTitleAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureSubTitle), "ur", content.FeatureSubTitleUr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureDescription), "en", content.FeatureDescriptionEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureDescription), "ar", content.FeatureDescriptionAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FeatureDescription), "ur", content.FeatureDescriptionUr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqTitle), "en", content.FaqTitleEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqTitle), "ar", content.FaqTitleAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqTitle), "ur", content.FaqTitleUr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqSubTitle), "en", content.FaqSubTitleEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqSubTitle), "ar", content.FaqSubTitleAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqSubTitle), "ur", content.FaqSubTitleUr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqDescription), "en", content.FaqDescriptionEn);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqDescription), "ar", content.FaqDescriptionAr);
+                SaveTranslation(nameof(IndexContent), entity.IndexContentId, nameof(IndexContent.FaqDescription), "ur", content.FaqDescriptionUr);
                 return true;
             }
             catch
@@ -674,40 +818,91 @@ namespace Services
         }
 
 
-        public bool UpdateAboutUsContent(AboutUsContent content, IFormFile imageProduct, IFormFile downloadProduct)
+        public bool UpdateAboutUsContent(AboutUsContentCrudViewModel content, IFormFile imageProduct, IFormFile downloadProduct)
         {
             try
             {
+                var entity = db.AboutUsContents.Find(content.AboutUsContentId);
+                entity.SubTitle = content.SubTitle;
+                entity.Title = content.Title;
+                entity.Description = content.Description;
+                entity.SecondSubTitle = content.SecondSubTitle;
+                entity.SecondTitle = content.SecondTitle;
+                entity.SecondDescription = content.SecondDescription;
+                entity.ThirdSubTitle = content.ThirdSubTitle;
+                entity.ThirdTitle = content.ThirdTitle;
+                entity.ForthSubTitle = content.ForthSubTitle;
+                entity.ForthTitle = content.ForthTitle;
+                entity.ForthDescription = content.ForthDescription;
+                entity.LogoTitle = content.LogoTitle;
+                entity.LogoSubTitle = content.LogoSubTitle;
+                entity.LogoDescription = content.LogoDescription;
                 if (imageProduct != null)
                 {
-                    string imagePath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", content.ImageName);
-
+                    string imagePath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", entity.ImageName);
                     System.IO.File.Delete(imagePath);
-
-                    content.ImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(imageProduct.FileName);
-                    string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", content.ImageName);
+                    entity.ImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(imageProduct.FileName);
+                    string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", entity.ImageName);
                     using (var stream = new FileStream(fullPath, FileMode.Create))
                     {
                         imageProduct.CopyTo(stream);
                     }
-
                 }
                 if (downloadProduct != null)
                 {
-                    string imagePath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", content.DownloadImageName);
-
+                    string imagePath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", entity.DownloadImageName);
                     System.IO.File.Delete(imagePath);
-
-                    content.DownloadImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(downloadProduct.FileName);
-                    string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", content.DownloadImageName);
+                    entity.DownloadImageName = Guid.NewGuid().ToString().Replace("-", "") + Path.GetExtension(downloadProduct.FileName);
+                    string fullPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot/Images/Site", entity.DownloadImageName);
                     using (var stream = new FileStream(fullPath, FileMode.Create))
                     {
                         downloadProduct.CopyTo(stream);
                     }
-
                 }
-                db.AboutUsContents.Update(content);
+                db.AboutUsContents.Update(entity);
                 db.SaveChanges();
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.SubTitle), "en", content.SubTitleEn);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.SubTitle), "ar", content.SubTitleAr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.SubTitle), "ur", content.SubTitleUr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.Title), "en", content.TitleEn);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.Title), "ar", content.TitleAr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.Title), "ur", content.TitleUr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.Description), "en", content.DescriptionEn);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.Description), "ar", content.DescriptionAr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.Description), "ur", content.DescriptionUr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.SecondSubTitle), "en", content.SecondSubTitleEn);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.SecondSubTitle), "ar", content.SecondSubTitleAr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.SecondSubTitle), "ur", content.SecondSubTitleUr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.SecondTitle), "en", content.SecondTitleEn);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.SecondTitle), "ar", content.SecondTitleAr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.SecondTitle), "ur", content.SecondTitleUr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.SecondDescription), "en", content.SecondDescriptionEn);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.SecondDescription), "ar", content.SecondDescriptionAr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.SecondDescription), "ur", content.SecondDescriptionUr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.ThirdSubTitle), "en", content.ThirdSubTitleEn);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.ThirdSubTitle), "ar", content.ThirdSubTitleAr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.ThirdSubTitle), "ur", content.ThirdSubTitleUr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.ThirdTitle), "en", content.ThirdTitleEn);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.ThirdTitle), "ar", content.ThirdTitleAr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.ThirdTitle), "ur", content.ThirdTitleUr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.ForthSubTitle), "en", content.ForthSubTitleEn);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.ForthSubTitle), "ar", content.ForthSubTitleAr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.ForthSubTitle), "ur", content.ForthSubTitleUr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.ForthTitle), "en", content.ForthTitleEn);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.ForthTitle), "ar", content.ForthTitleAr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.ForthTitle), "ur", content.ForthTitleUr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.ForthDescription), "en", content.ForthDescriptionEn);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.ForthDescription), "ar", content.ForthDescriptionAr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.ForthDescription), "ur", content.ForthDescriptionUr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.LogoTitle), "en", content.LogoTitleEn);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.LogoTitle), "ar", content.LogoTitleAr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.LogoTitle), "ur", content.LogoTitleUr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.LogoSubTitle), "en", content.LogoSubTitleEn);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.LogoSubTitle), "ar", content.LogoSubTitleAr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.LogoSubTitle), "ur", content.LogoSubTitleUr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.LogoDescription), "en", content.LogoDescriptionEn);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.LogoDescription), "ar", content.LogoDescriptionAr);
+                SaveTranslation(nameof(AboutUsContent), entity.AboutUsContentId, nameof(AboutUsContent.LogoDescription), "ur", content.LogoDescriptionUr);
                 return true;
             }
             catch
@@ -716,12 +911,37 @@ namespace Services
             }
         }
 
-        public bool UpdateContactUsContent(ContactUsContent content)
+        public bool UpdateContactUsContent(ContactUsContentCrudViewModel content)
         {
             try
             {
-                db.ContactUsContents.Update(content);
+                var entity = db.ContactUsContents.Find(content.ContactUsContentId);
+                entity.FirstSubTitle = content.FirstSubTitle;
+                entity.FirstTitle = content.FirstTitle;
+                entity.FristDescription = content.FristDescription;
+                entity.SecondSubTitle = content.SecondSubTitle;
+                entity.SecondTitle = content.SecondTitle;
+                entity.SecondDescription = content.SecondDescription;
+                db.ContactUsContents.Update(entity);
                 db.SaveChanges();
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FirstSubTitle), "en", content.FirstSubTitleEn);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FirstSubTitle), "ar", content.FirstSubTitleAr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FirstSubTitle), "ur", content.FirstSubTitleUr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FirstTitle), "en", content.FirstTitleEn);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FirstTitle), "ar", content.FirstTitleAr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FirstTitle), "ur", content.FirstTitleUr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FristDescription), "en", content.FristDescriptionEn);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FristDescription), "ar", content.FristDescriptionAr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.FristDescription), "ur", content.FristDescriptionUr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondSubTitle), "en", content.SecondSubTitleEn);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondSubTitle), "ar", content.SecondSubTitleAr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondSubTitle), "ur", content.SecondSubTitleUr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondTitle), "en", content.SecondTitleEn);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondTitle), "ar", content.SecondTitleAr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondTitle), "ur", content.SecondTitleUr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondDescription), "en", content.SecondDescriptionEn);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondDescription), "ar", content.SecondDescriptionAr);
+                SaveTranslation(nameof(ContactUsContent), entity.ContactUsContentId, nameof(ContactUsContent.SecondDescription), "ur", content.SecondDescriptionUr);
                 return true;
             }
             catch
@@ -730,11 +950,38 @@ namespace Services
             }
         }
 
-        public ContactUsContent GetContactUsContent()
+        public ContactUsContentCrudViewModel GetContactUsContent()
         {
             var item = db.ContactUsContents.FirstOrDefault();
-            item.ApplyTranslation(db);
-            return item;
+            var translations = db.EntityTranslations.Where(t => t.EntityName == nameof(ContactUsContent) && t.EntityId == item.ContactUsContentId).ToList();
+            return new ContactUsContentCrudViewModel
+            {
+                ContactUsContentId = item.ContactUsContentId,
+                FirstSubTitle = item.FirstSubTitle,
+                FirstTitle = item.FirstTitle,
+                FristDescription = item.FristDescription,
+                SecondSubTitle = item.SecondSubTitle,
+                SecondTitle = item.SecondTitle,
+                SecondDescription = item.SecondDescription,
+                FirstSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FirstSubTitle) && t.Culture == "en")?.Value,
+                FirstSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FirstSubTitle) && t.Culture == "ar")?.Value,
+                FirstSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FirstSubTitle) && t.Culture == "ur")?.Value,
+                FirstTitleEn = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FirstTitle) && t.Culture == "en")?.Value,
+                FirstTitleAr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FirstTitle) && t.Culture == "ar")?.Value,
+                FirstTitleUr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FirstTitle) && t.Culture == "ur")?.Value,
+                FristDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FristDescription) && t.Culture == "en")?.Value,
+                FristDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FristDescription) && t.Culture == "ar")?.Value,
+                FristDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.FristDescription) && t.Culture == "ur")?.Value,
+                SecondSubTitleEn = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondSubTitle) && t.Culture == "en")?.Value,
+                SecondSubTitleAr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondSubTitle) && t.Culture == "ar")?.Value,
+                SecondSubTitleUr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondSubTitle) && t.Culture == "ur")?.Value,
+                SecondTitleEn = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondTitle) && t.Culture == "en")?.Value,
+                SecondTitleAr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondTitle) && t.Culture == "ar")?.Value,
+                SecondTitleUr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondTitle) && t.Culture == "ur")?.Value,
+                SecondDescriptionEn = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondDescription) && t.Culture == "en")?.Value,
+                SecondDescriptionAr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondDescription) && t.Culture == "ar")?.Value,
+                SecondDescriptionUr = translations.FirstOrDefault(t => t.Property == nameof(ContactUsContent.SecondDescription) && t.Culture == "ur")?.Value
+            };
         }
 
         public List<DownloadLinkGroupViewModel> GetDownloadLinkGoroups()
@@ -753,9 +1000,28 @@ namespace Services
             return content;
         }
 
-        
+
 
 
         #endregion Contents
+
+        private void SaveTranslation(string entityName, int entityId, string property, string culture, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return;
+            var tr = db.EntityTranslations.FirstOrDefault(t => t.EntityName == entityName && t.EntityId == entityId && t.Property == property && t.Culture == culture);
+            if (tr == null)
+            {
+                tr = new EntityTranslation
+                {
+                    EntityName = entityName,
+                    EntityId = entityId,
+                    Property = property,
+                    Culture = culture
+                };
+                db.EntityTranslations.Add(tr);
+            }
+            tr.Value = value;
+            db.SaveChanges();
+        }
     }
 }

--- a/Services/Services/SlidersRepository.cs
+++ b/Services/Services/SlidersRepository.cs
@@ -107,6 +107,28 @@ namespace Services
             return item;
         }
 
+        public SliderCrudViewModel GetForEdit(int sliderId)
+        {
+            var slider = db.Sliders.Find(sliderId);
+            var model = new SliderCrudViewModel
+            {
+                SliderId = slider.SliderId,
+                SliderGroupId = slider.SliderGroupId,
+                Title = slider.Title,
+                ShortDescription = slider.ShortDescription,
+                Link = slider.Link,
+                ImageName = slider.ImageName
+            };
+            var tr = db.EntityTranslations.ToList();
+            model.TitleEn = tr.FirstOrDefault(t => t.EntityName == nameof(Slider) && t.EntityId == sliderId && t.Property == nameof(Slider.Title) && t.Culture == "en")?.Value;
+            model.TitleAr = tr.FirstOrDefault(t => t.EntityName == nameof(Slider) && t.EntityId == sliderId && t.Property == nameof(Slider.Title) && t.Culture == "ar")?.Value;
+            model.TitleUr = tr.FirstOrDefault(t => t.EntityName == nameof(Slider) && t.EntityId == sliderId && t.Property == nameof(Slider.Title) && t.Culture == "ur")?.Value;
+            model.ShortDescriptionEn = tr.FirstOrDefault(t => t.EntityName == nameof(Slider) && t.EntityId == sliderId && t.Property == nameof(Slider.ShortDescription) && t.Culture == "en")?.Value;
+            model.ShortDescriptionAr = tr.FirstOrDefault(t => t.EntityName == nameof(Slider) && t.EntityId == sliderId && t.Property == nameof(Slider.ShortDescription) && t.Culture == "ar")?.Value;
+            model.ShortDescriptionUr = tr.FirstOrDefault(t => t.EntityName == nameof(Slider) && t.EntityId == sliderId && t.Property == nameof(Slider.ShortDescription) && t.Culture == "ur")?.Value;
+            return model;
+        }
+
         public List<IndexSliderItemViewModel> GetContactUsSlider()
         {
             var content = db.Sliders.Where(s => s.SliderGroupId == 6).OrderByDescending(s => s.SliderId).ToList();
@@ -237,6 +259,42 @@ namespace Services
                 return false;
             }
 
+        }
+
+        public void SaveTranslations(SliderCrudViewModel slider)
+        {
+            SaveTranslation(nameof(Slider), slider.SliderId, nameof(Slider.Title), "en", slider.TitleEn);
+            SaveTranslation(nameof(Slider), slider.SliderId, nameof(Slider.Title), "ar", slider.TitleAr);
+            SaveTranslation(nameof(Slider), slider.SliderId, nameof(Slider.Title), "ur", slider.TitleUr);
+            SaveTranslation(nameof(Slider), slider.SliderId, nameof(Slider.ShortDescription), "en", slider.ShortDescriptionEn);
+            SaveTranslation(nameof(Slider), slider.SliderId, nameof(Slider.ShortDescription), "ar", slider.ShortDescriptionAr);
+            SaveTranslation(nameof(Slider), slider.SliderId, nameof(Slider.ShortDescription), "ur", slider.ShortDescriptionUr);
+        }
+
+        private void SaveTranslation(string entityName, int entityId, string property, string culture, string value)
+        {
+            var tr = db.EntityTranslations.FirstOrDefault(t => t.EntityName == entityName && t.EntityId == entityId && t.Property == property && t.Culture == culture);
+            if (tr == null)
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    db.EntityTranslations.Add(new EntityTranslation
+                    {
+                        EntityName = entityName,
+                        EntityId = entityId,
+                        Property = property,
+                        Culture = culture,
+                        Value = value
+                    });
+                    db.SaveChanges();
+                }
+            }
+            else
+            {
+                tr.Value = value;
+                db.EntityTranslations.Update(tr);
+                db.SaveChanges();
+            }
         }
     }
 }

--- a/Twelve/Areas/Admin/Controllers/AboutUsArticlesController.cs
+++ b/Twelve/Areas/Admin/Controllers/AboutUsArticlesController.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Services;
-
+using ViewModels;
 namespace Twelve.Areas.Admin.Controllers
 {
     [Authorize]
@@ -33,38 +33,40 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Create")]
-        public IActionResult Create(AboutUsArticle article, IFormFile imageProduct)
+        public IActionResult Create(AboutUsArticleCrudViewModel article, IFormFile imageProduct)
         {
             if (aboutUsArticlesRepository.Create(article, imageProduct))
             {
+                aboutUsArticlesRepository.SaveTranslations(article);
                 return RedirectToAction("index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                return View();
+                return View(article);
             }
         }
 
         [Route("Update/{ArticleID}")]
         public IActionResult Update(int articleID)
         {
-            var content = aboutUsArticlesRepository.GetByID(articleID);
+            var content = aboutUsArticlesRepository.GetForEdit(articleID);
             return View(content);
         }
 
         [HttpPost]
         [Route("Update/{ArticleID}")]
-        public IActionResult Update(AboutUsArticle article, IFormFile imageProduct)
+        public IActionResult Update(AboutUsArticleCrudViewModel article, IFormFile imageProduct)
         {
             if (aboutUsArticlesRepository.Update(article, imageProduct))
             {
+                aboutUsArticlesRepository.SaveTranslations(article);
                 return RedirectToAction("index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = aboutUsArticlesRepository.GetByID(article.AboutUsArticleId);
+                var content = aboutUsArticlesRepository.GetForEdit(article.AboutUsArticleId);
                 return View(content);
             }
         }

--- a/Twelve/Areas/Admin/Controllers/AboutUsItemsController.cs
+++ b/Twelve/Areas/Admin/Controllers/AboutUsItemsController.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Services;
-
+using ViewModels;
 namespace Twelve.Areas.Admin.Controllers
 {
     [Authorize]
@@ -33,38 +33,40 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Create")]
-        public IActionResult Create(AboutUsItem item, IFormFile imageProduct)
+        public IActionResult Create(AboutUsItemCrudViewModel item, IFormFile imageProduct)
         {
             if (aboutUsItemsRepository.Create(item, imageProduct))
             {
+                aboutUsItemsRepository.SaveTranslations(item);
                 return RedirectToAction("index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                return View();
+                return View(item);
             }
         }
 
         [Route("Update/{ItemID}")]
         public IActionResult Update(int itemID)
         {
-            var content = aboutUsItemsRepository.GetByID(itemID);
+            var content = aboutUsItemsRepository.GetForEdit(itemID);
             return View(content);
         }
 
         [HttpPost]
         [Route("Update/{ItemID}")]
-        public IActionResult Update(AboutUsItem item, IFormFile imageProduct)
+        public IActionResult Update(AboutUsItemCrudViewModel item, IFormFile imageProduct)
         {
             if (aboutUsItemsRepository.Update(item, imageProduct))
             {
+                aboutUsItemsRepository.SaveTranslations(item);
                 return RedirectToAction("index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = aboutUsItemsRepository.GetByID(item.AboutUsItemId);
+                var content = aboutUsItemsRepository.GetForEdit(item.AboutUsItemId);
                 return View(content);
             }
         }

--- a/Twelve/Areas/Admin/Controllers/AboutUsSightController.cs
+++ b/Twelve/Areas/Admin/Controllers/AboutUsSightController.cs
@@ -35,38 +35,40 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Create")]
-        public IActionResult Create(AboutUsSight sight, IFormFile imageProduct)
+        public IActionResult Create(AboutUsSightCrudViewModel sight, IFormFile imageProduct)
         {
             if (aboutUsSightRepository.Create(sight, imageProduct))
             {
+                aboutUsSightRepository.SaveTranslations(sight);
                 return RedirectToAction("index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                return View();
+                return View(sight);
             }
         }
 
         [Route("Update/{SightID}")]
         public IActionResult Update(int sightID)
         {
-            var content = aboutUsSightRepository.GetByID(sightID);
+            var content = aboutUsSightRepository.GetForEdit(sightID);
             return View(content);
         }
 
         [HttpPost]
         [Route("Update/{SightID}")]
-        public IActionResult Update(AboutUsSight sight , IFormFile imageProduct)
+        public IActionResult Update(AboutUsSightCrudViewModel sight, IFormFile imageProduct)
         {
             if (aboutUsSightRepository.Update(sight, imageProduct))
             {
+                aboutUsSightRepository.SaveTranslations(sight);
                 return RedirectToAction("index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = aboutUsSightRepository.GetByID(sight.AboutUsSightId);
+                var content = aboutUsSightRepository.GetForEdit(sight.AboutUsSightId);
                 return View(content);
             }
         }

--- a/Twelve/Areas/Admin/Controllers/AdvertisementsController.cs
+++ b/Twelve/Areas/Admin/Controllers/AdvertisementsController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Services;
+using ViewModels;
 
 namespace Twelve.Areas.Admin.Controllers
 {
@@ -30,7 +31,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "لیست تبلیغات"))
             {
-                return View();
+                return View(new AdvertisementCrudViewModel());
             }
             else
             {
@@ -40,21 +41,29 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Create")]
-        public IActionResult Create(Advertisement Advertisements, IFormFile imageProduct)
+        public IActionResult Create(AdvertisementCrudViewModel advertisement, IFormFile imageProduct)
         {
             if (imageProduct == null)
             {
                 ViewBag.Message = "لطفا تصویر مورد نظر را وارد کنید";
-                return View();
+                return View(advertisement);
             }
-            if (advertisementsRepository.Create(Advertisements, imageProduct))
+            var entity = new Advertisement
             {
+                Title = advertisement.Title,
+                Link = advertisement.Link,
+                IsBanner = advertisement.IsBanner
+            };
+            if (advertisementsRepository.Create(entity, imageProduct))
+            {
+                advertisement.AdvertisementId = entity.AdvertisementId;
+                advertisementsRepository.SaveTranslations(advertisement);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                return View();
+                return View(advertisement);
             }
         }
 
@@ -63,7 +72,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "لیست تبلیغات"))
             {
-                var content = advertisementsRepository.GetByID(InfoID);
+                var content = advertisementsRepository.GetForEdit(InfoID);
                 return View(content);
             }
             else
@@ -74,24 +83,33 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Update/{InfoID}")]
-        public IActionResult Update(Advertisement Advertisements, IFormFile imageProduct)
+        public IActionResult Update(AdvertisementCrudViewModel advertisement, IFormFile imageProduct)
         {
             if (ModelState.IsValid)
             {
-                if (advertisementsRepository.Update(Advertisements, imageProduct))
+                var entity = new Advertisement
                 {
+                    AdvertisementId = advertisement.AdvertisementId,
+                    Title = advertisement.Title,
+                    Link = advertisement.Link,
+                    IsBanner = advertisement.IsBanner,
+                    ImageName = advertisement.ImageName
+                };
+                if (advertisementsRepository.Update(entity, imageProduct))
+                {
+                    advertisementsRepository.SaveTranslations(advertisement);
                     return RedirectToAction("Index");
                 }
                 else
                 {
                     ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                    return View();
+                    return View(advertisement);
                 }
             }
             else
             {
                 ViewBag.Message = "لطفا لینک مورد نظر را وارد کنید";
-                var content = advertisementsRepository.GetByID(Advertisements.AdvertisementId);
+                var content = advertisementsRepository.GetForEdit(advertisement.AdvertisementId);
                 return View(content);
             }
         }

--- a/Twelve/Areas/Admin/Controllers/BlogController.cs
+++ b/Twelve/Areas/Admin/Controllers/BlogController.cs
@@ -102,6 +102,7 @@ namespace Twelve.Areas.Admin.Controllers
             }
             if (blogRepository.Create(blog,imageProduct))
             {
+                blogRepository.SaveTranslations(blog);
                 return RedirectToAction("Index");
             }
             else
@@ -138,6 +139,7 @@ namespace Twelve.Areas.Admin.Controllers
             }
             if (blogRepository.Update(blog , imageProduct))
             {
+                blogRepository.SaveTranslations(blog);
                 return RedirectToAction("Index");
             }
             else

--- a/Twelve/Areas/Admin/Controllers/BlogGroupsController.cs
+++ b/Twelve/Areas/Admin/Controllers/BlogGroupsController.cs
@@ -32,7 +32,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "دسته بندی های اخبار"))
             {
-                return View();
+                return View(new BlogGroupCrudViewModel());
             }
             else
             {
@@ -42,16 +42,19 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Create")]
-        public IActionResult Create(BlogGroup blogGroup)
+        public IActionResult Create(BlogGroupCrudViewModel blogGroup)
         {
-            if (blogGroupsRepository.Create(blogGroup))
+            var entity = new BlogGroup { GroupName = blogGroup.GroupName, ParentId = blogGroup.ParentId };
+            if (blogGroupsRepository.Create(entity))
             {
+                blogGroup.BlogGroupId = entity.BlogGroupId;
+                blogGroupsRepository.SaveTranslations(blogGroup);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                return View();
+                return View(blogGroup);
             }
         }
 
@@ -60,7 +63,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "دسته بندی های اخبار"))
             {
-                var content = blogGroupsRepository.GetByID(InfoID);
+                var content = blogGroupsRepository.GetForEdit(InfoID);
                 return View(content);
             }
             else
@@ -71,16 +74,18 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Update/{InfoID}")]
-        public IActionResult Update(BlogGroup blogGroup)
+        public IActionResult Update(BlogGroupCrudViewModel blogGroup)
         {
-            if (blogGroupsRepository.Update(blogGroup))
+            var entity = new BlogGroup { BlogGroupId = blogGroup.BlogGroupId, GroupName = blogGroup.GroupName, ParentId = blogGroup.ParentId };
+            if (blogGroupsRepository.Update(entity))
             {
+                blogGroupsRepository.SaveTranslations(blogGroup);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = blogGroupsRepository.GetByID(blogGroup.BlogGroupId);
+                var content = blogGroupsRepository.GetForEdit(blogGroup.BlogGroupId);
                 return View(content);
             }
         }

--- a/Twelve/Areas/Admin/Controllers/CallInfoController.cs
+++ b/Twelve/Areas/Admin/Controllers/CallInfoController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Services;
+using ViewModels;
 
 namespace Twelve.Areas.Admin.Controllers
 {
@@ -30,7 +31,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "اطلاعات تماس"))
             {
-                return View();
+                return View(new CallInfoCrudViewModel());
             }
             else
             {
@@ -40,16 +41,24 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Create")]
-        public IActionResult Create(CallInfo callInfo , IFormFile imageProduct)
+        public IActionResult Create(CallInfoCrudViewModel callInfo , IFormFile imageProduct)
         {
-            if (callInfoRepository.Create(callInfo,imageProduct))
+            var entity = new CallInfo
             {
+                Title = callInfo.Title,
+                ShortDescription = callInfo.ShortDescription,
+                Description = callInfo.Description
+            };
+            if (callInfoRepository.Create(entity,imageProduct))
+            {
+                callInfo.CallInfoId = entity.CallInfoId;
+                callInfoRepository.SaveTranslations(callInfo);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                return View();
+                return View(callInfo);
             }
         }
 
@@ -58,7 +67,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "اطلاعات تماس"))
             {
-                var content = callInfoRepository.GetByID(InfoID);
+                var content = callInfoRepository.GetForEdit(InfoID);
                 return View(content);
             }
             else
@@ -69,16 +78,25 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Update/{InfoID}")]
-        public IActionResult Update(CallInfo callInfo, IFormFile imageProduct)
+        public IActionResult Update(CallInfoCrudViewModel callInfo, IFormFile imageProduct)
         {
-            if (callInfoRepository.Update(callInfo, imageProduct))
+            var entity = new CallInfo
             {
+                CallInfoId = callInfo.CallInfoId,
+                Title = callInfo.Title,
+                ShortDescription = callInfo.ShortDescription,
+                Description = callInfo.Description,
+                ImageName = callInfo.ImageName
+            };
+            if (callInfoRepository.Update(entity, imageProduct))
+            {
+                callInfoRepository.SaveTranslations(callInfo);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = callInfoRepository.GetByID(callInfo.CallInfoId);
+                var content = callInfoRepository.GetForEdit(callInfo.CallInfoId);
                 return View(content);
             }
         }

--- a/Twelve/Areas/Admin/Controllers/FaqController.cs
+++ b/Twelve/Areas/Admin/Controllers/FaqController.cs
@@ -52,6 +52,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (faqsRepository.Create(faqs))
             {
+                faqsRepository.SaveTranslations(faqs);
                 return RedirectToAction("Index");
             }
             else
@@ -82,6 +83,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (faqsRepository.Update(faqs))
             {
+                faqsRepository.SaveTranslations(faqs);
                 return RedirectToAction("Index");
             }
             else

--- a/Twelve/Areas/Admin/Controllers/FaqsGroupController.cs
+++ b/Twelve/Areas/Admin/Controllers/FaqsGroupController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Services;
+using ViewModels;
 
 namespace Twelve.Areas.Admin.Controllers
 {
@@ -31,7 +32,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "دسته بندی های اخبار"))
             {
-                return View();
+                return View(new FaqGroupCrudViewModel());
             }
             else
             {
@@ -41,16 +42,19 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Create")]
-        public IActionResult Create(FaqGroup faqGroup)
+        public IActionResult Create(FaqGroupCrudViewModel faqGroup)
         {
-            if (faqsRepository.CreateGroup(faqGroup))
+            FaqGroup entity = new FaqGroup { GroupName = faqGroup.GroupName, ParentId = faqGroup.ParentId };
+            if (faqsRepository.CreateGroup(entity))
             {
+                faqGroup.FaqGroupId = entity.FaqGroupId;
+                faqsRepository.SaveGroupTranslations(faqGroup);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                return View();
+                return View(faqGroup);
             }
         }
 
@@ -59,7 +63,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "دسته بندی های اخبار"))
             {
-                var content = faqsRepository.GetGroupByID(InfoID);
+                var content = faqsRepository.GetGroupForEdit(InfoID);
                 return View(content);
             }
             else
@@ -70,16 +74,18 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Update/{InfoID}")]
-        public IActionResult Update(FaqGroup faqGroup)
+        public IActionResult Update(FaqGroupCrudViewModel faqGroup)
         {
-            if (faqsRepository.UpdateGroup(faqGroup))
+            FaqGroup entity = new FaqGroup { FaqGroupId = faqGroup.FaqGroupId, GroupName = faqGroup.GroupName, ParentId = faqGroup.ParentId };
+            if (faqsRepository.UpdateGroup(entity))
             {
+                faqsRepository.SaveGroupTranslations(faqGroup);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = faqsRepository.GetByID(faqGroup.FaqGroupId);
+                var content = faqsRepository.GetGroupForEdit(faqGroup.FaqGroupId);
                 return View(content);
             }
         }

--- a/Twelve/Areas/Admin/Controllers/FeaturesController.cs
+++ b/Twelve/Areas/Admin/Controllers/FeaturesController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Services;
+using ViewModels;
 
 namespace Twelve.Areas.Admin.Controllers
 {
@@ -51,7 +52,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "ویژگی ها"))
             {
-                return View();
+                return View(new FeatureCrudViewModel());
             }
             else
             {
@@ -61,32 +62,43 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Create")]
-        public IActionResult Create(Feature feature, IFormFile imageProduct, IFormFile animeteFile, IFormFile imageFAProduct, IFormFile imageSAProduct , IFormFile introduceProduct)
+        public IActionResult Create(FeatureCrudViewModel feature, IFormFile imageProduct, IFormFile animeteFile, IFormFile imageFAProduct, IFormFile imageSAProduct , IFormFile introduceProduct)
         {
             if (imageProduct == null)
             {
                 ViewBag.Message = "لطفا تصویر مربوطه را وارد کنید";
-                return View();
+                return View(feature);
             }
             if (animeteFile == null)
             {
                 ViewBag.Message = "لطفا فایل انیمیشن مربوطه را وارد کنید";
-                return View();
+                return View(feature);
             }
             if (introduceProduct == null)
             {
                 ViewBag.Message = "لطفا تصویر معرفی نرم افزار در صفحه اول مربوطه را وارد کنید";
-                return View();
+                return View(feature);
             }
-
-            if (featuresRepository.Create(feature, imageProduct,animeteFile,imageFAProduct,imageSAProduct,introduceProduct))
+            var entity = new Feature
             {
+                Title = feature.Title,
+                ShortDescription = feature.ShortDescription,
+                FirstDescription = feature.FirstDescription,
+                FirstArticleTitle = feature.FirstArticleTitle,
+                FirstArticleDescription = feature.FirstArticleDescription,
+                SecondArticleTitle = feature.SecondArticleTitle,
+                SecondArticleDescription = feature.SecondArticleDescription
+            };
+            if (featuresRepository.Create(entity, imageProduct, animeteFile, imageFAProduct, imageSAProduct, introduceProduct))
+            {
+                feature.FeatureId = entity.FeatureId;
+                featuresRepository.SaveTranslations(feature);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                return View();
+                return View(feature);
             }
         }
 
@@ -95,7 +107,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "ویژگی ها"))
             {
-                var content = featuresRepository.GetByID(featureID);
+                var content = featuresRepository.GetForEdit(featureID);
                 return View(content);
             }
             else
@@ -106,16 +118,33 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Update/{FeatureID}")]
-        public IActionResult Update(Feature feature, IFormFile imageProduct, IFormFile animeteFile, IFormFile imageFAProduct, IFormFile imageSAProduct, IFormFile introduceProduct)
+        public IActionResult Update(FeatureCrudViewModel feature, IFormFile imageProduct, IFormFile animeteFile, IFormFile imageFAProduct, IFormFile imageSAProduct, IFormFile introduceProduct)
         {
-            if (featuresRepository.Update(feature, imageProduct, animeteFile, imageFAProduct, imageSAProduct, introduceProduct))
+            var entity = new Feature
             {
+                FeatureId = feature.FeatureId,
+                Title = feature.Title,
+                ShortDescription = feature.ShortDescription,
+                FirstDescription = feature.FirstDescription,
+                FirstArticleTitle = feature.FirstArticleTitle,
+                FirstArticleDescription = feature.FirstArticleDescription,
+                SecondArticleTitle = feature.SecondArticleTitle,
+                SecondArticleDescription = feature.SecondArticleDescription,
+                ImageName = feature.ImageName,
+                AnimateFilename = feature.AnimateFilename,
+                FirstArticleImage = feature.FirstArticleImage,
+                SecondArticleImage = feature.SecondArticleImage,
+                IntroduceImageName = feature.IntroduceImageName
+            };
+            if (featuresRepository.Update(entity, imageProduct, animeteFile, imageFAProduct, imageSAProduct, introduceProduct))
+            {
+                featuresRepository.SaveTranslations(feature);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = featuresRepository.GetByID(feature.FeatureId);
+                var content = featuresRepository.GetForEdit(feature.FeatureId);
                 return View(content);
             }
         }
@@ -204,7 +233,7 @@ namespace Twelve.Areas.Admin.Controllers
             if (adminRepository.CheckPermission(User.Identity.Name, "ویژگی ها"))
             {
                 ViewBag.FeatureID = FeatureID;
-                return View();
+                return View(new FeatureItemCrudViewModel { FeatureId = FeatureID });
             }
             else
             {
@@ -214,17 +243,25 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("CreateItem/{FeatureID}")]
-        public IActionResult CreateItem(FeatureItem featureItem, IFormFile imageProduct)
+        public IActionResult CreateItem(FeatureItemCrudViewModel featureItem, IFormFile imageProduct)
         {
-            if (featuresRepository.CreateItem(featureItem, imageProduct))
+            var entity = new FeatureItem
             {
+                FeatureId = featureItem.FeatureId,
+                Title = featureItem.Title,
+                ShortDescription = featureItem.ShortDescription
+            };
+            if (featuresRepository.CreateItem(entity, imageProduct))
+            {
+                featureItem.FeaturesItemId = entity.FeaturesItemId;
+                featuresRepository.SaveItemTranslations(featureItem);
                 return RedirectToAction("ShowItems", new { FeatureID = featureItem.FeatureId });
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
                 ViewBag.FeatureID = featureItem.FeatureId;
-                return View();
+                return View(featureItem);
             }
         }
 
@@ -233,7 +270,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "ویژگی ها"))
             {
-                var content = featuresRepository.GetItemByID(InfoID);
+                var content = featuresRepository.GetItemForEdit(InfoID);
                 return View(content);
             }
             else
@@ -244,16 +281,25 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("UpdateItem/{InfoID}")]
-        public IActionResult UpdateItem(FeatureItem featureItem, IFormFile imageProduct)
+        public IActionResult UpdateItem(FeatureItemCrudViewModel featureItem, IFormFile imageProduct)
         {
-            if (featuresRepository.UpdateItem(featureItem, imageProduct))
+            var entity = new FeatureItem
             {
+                FeaturesItemId = featureItem.FeaturesItemId,
+                FeatureId = featureItem.FeatureId,
+                Title = featureItem.Title,
+                ShortDescription = featureItem.ShortDescription,
+                ImageName = featureItem.ImageName
+            };
+            if (featuresRepository.UpdateItem(entity, imageProduct))
+            {
+                featuresRepository.SaveItemTranslations(featureItem);
                 return RedirectToAction("ShowItems", new { FeatureID = featureItem.FeatureId });
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = featuresRepository.GetItemByID(featureItem.FeaturesItemId);
+                var content = featuresRepository.GetItemForEdit(featureItem.FeaturesItemId);
                 return View(content);
             }
         }

--- a/Twelve/Areas/Admin/Controllers/HomeController.cs
+++ b/Twelve/Areas/Admin/Controllers/HomeController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Services;
+using ViewModels;
 
 namespace Twelve.Areas.Admin.Controllers
 {
@@ -72,7 +73,7 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("IndexContent")]
-        public IActionResult IndexContent(IndexContent indexContent)
+        public IActionResult IndexContent(IndexContentCrudViewModel indexContent)
         {
             if (siteRepository.UpdateIndexContent(indexContent))
             {
@@ -93,7 +94,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "تنظیمات"))
             {
-                var content = siteRepository.GetAboutUsContent();
+                var content = siteRepository.GetAboutUsContentForEdit();
                 return View(content);
             }
             else
@@ -104,18 +105,18 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("AboutUsContent")]
-        public IActionResult AboutUsContent(AboutUsContent aboutUsContent, IFormFile imageProduct , IFormFile downloadProduct)
+        public IActionResult AboutUsContent(AboutUsContentCrudViewModel aboutUsContent, IFormFile imageProduct, IFormFile downloadProduct)
         {
-            if (siteRepository.UpdateAboutUsContent(aboutUsContent,imageProduct,downloadProduct))
+            if (siteRepository.UpdateAboutUsContent(aboutUsContent, imageProduct, downloadProduct))
             {
                 ViewBag.Message = "عملیات با موفقیت انجام شد";
-                var content = siteRepository.GetAboutUsContent();
+                var content = siteRepository.GetAboutUsContentForEdit();
                 return View(content);
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = siteRepository.GetAboutUsContent();
+                var content = siteRepository.GetAboutUsContentForEdit();
                 return View(content);
             }
         }
@@ -136,7 +137,7 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("ContactUsContent")]
-        public IActionResult ContactUsContent(ContactUsContent contactUsContent)
+        public IActionResult ContactUsContent(ContactUsContentCrudViewModel contactUsContent)
         {
             if (siteRepository.UpdateContactUsContent(contactUsContent))
             {
@@ -158,7 +159,7 @@ namespace Twelve.Areas.Admin.Controllers
             if (adminRepository.CheckPermission(User.Identity.Name, "تنظیمات"))
             {
                 IFaqsRepository faqsRepository = new FaqsRepository();
-                var content = faqsRepository.GetFaqContent();
+                var content = faqsRepository.GetFaqContentForEdit();
                 return View(content);
             }
             else
@@ -169,20 +170,20 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("FaqContent")]
-        public IActionResult FaqContent(FaqContent aboutUsContent)
+        public IActionResult FaqContent(FaqContentCrudViewModel aboutUsContent)
         {
             IFaqsRepository faqsRepository = new FaqsRepository();
 
             if (faqsRepository.UpdateFaqContent(aboutUsContent))
             {
                 ViewBag.Message = "عملیات با موفقیت انجام شد";
-                var content = faqsRepository.GetFaqContent();
+                var content = faqsRepository.GetFaqContentForEdit();
                 return View(content);
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = faqsRepository.GetFaqContent();
+                var content = faqsRepository.GetFaqContentForEdit();
                 return View(content);
             }
         }
@@ -193,7 +194,7 @@ namespace Twelve.Areas.Admin.Controllers
             if (adminRepository.CheckPermission(User.Identity.Name, "تنظیمات"))
             {
                 IFeaturesRepository featuresRepository = new FeaturesRepository();
-                var content = featuresRepository.GetFeaturesContent();
+                var content = featuresRepository.GetFeaturesContentForEdit();
                 return View(content);
             }
             else
@@ -204,20 +205,20 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("AppMenuContent")]
-        public IActionResult AppMenuContent(FeaturesContent featuresContent)
+        public IActionResult AppMenuContent(FeaturesContentCrudViewModel featuresContent)
         {
             IFeaturesRepository featuresRepository = new FeaturesRepository();
 
             if (featuresRepository.UpdateFeaturesContent(featuresContent))
             {
                 ViewBag.Message = "عملیات با موفقیت انجام شد";
-                var content = featuresRepository.GetFeaturesContent();
+                var content = featuresRepository.GetFeaturesContentForEdit();
                 return View(content);
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = featuresRepository.GetFeaturesContent();
+                var content = featuresRepository.GetFeaturesContentForEdit();
                 return View(content);
             }
         }

--- a/Twelve/Areas/Admin/Controllers/IntroducesController.cs
+++ b/Twelve/Areas/Admin/Controllers/IntroducesController.cs
@@ -47,6 +47,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (introducesRepository.Create(introduce))
             {
+                introducesRepository.SaveTranslations(introduce);
                 return RedirectToAction("Index");
             }
             else
@@ -77,6 +78,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (introducesRepository.Update(introduce))
             {
+                introducesRepository.SaveTranslations(introduce);
                 return RedirectToAction("Index");
             }
             else

--- a/Twelve/Areas/Admin/Controllers/SlidersController.cs
+++ b/Twelve/Areas/Admin/Controllers/SlidersController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Services;
 using System.Text.RegularExpressions;
+using ViewModels;
 
 namespace Twelve.Areas.Admin.Controllers
 {
@@ -45,8 +46,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "اسلایدر ها"))
             {
-                ViewBag.GroupID = GroupID;
-                return View();
+                return View(new SliderCrudViewModel { SliderGroupId = GroupID });
             }
             else
             {
@@ -56,17 +56,25 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Create/{GroupID}")]
-        public IActionResult Create(Slider slider, IFormFile imageProduct)
+        public IActionResult Create(SliderCrudViewModel slider, IFormFile imageProduct)
         {
-            if (slidersRepository.Create(slider, imageProduct))
+            var entity = new Slider
             {
+                SliderGroupId = slider.SliderGroupId,
+                Title = slider.Title,
+                ShortDescription = slider.ShortDescription,
+                Link = slider.Link
+            };
+            if (slidersRepository.Create(entity, imageProduct))
+            {
+                slider.SliderId = entity.SliderId;
+                slidersRepository.SaveTranslations(slider);
                 return RedirectToAction("Index");
             }
             else
             {
-                ViewBag.GroupID = slider.SliderGroupId;
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                return View();
+                return View(slider);
             }
         }
 
@@ -75,7 +83,7 @@ namespace Twelve.Areas.Admin.Controllers
         {
             if (adminRepository.CheckPermission(User.Identity.Name, "اسلایدر ها"))
             {
-                var content = slidersRepository.GetByID(InfoID);
+                var content = slidersRepository.GetForEdit(InfoID);
                 return View(content);
             }
             else
@@ -86,16 +94,26 @@ namespace Twelve.Areas.Admin.Controllers
 
         [HttpPost]
         [Route("Update/{InfoID}")]
-        public IActionResult Update(Slider slider, IFormFile imageProduct)
+        public IActionResult Update(SliderCrudViewModel slider, IFormFile imageProduct)
         {
-            if (slidersRepository.Update(slider, imageProduct))
+            var entity = new Slider
             {
+                SliderId = slider.SliderId,
+                SliderGroupId = slider.SliderGroupId,
+                Title = slider.Title,
+                ShortDescription = slider.ShortDescription,
+                Link = slider.Link,
+                ImageName = slider.ImageName
+            };
+            if (slidersRepository.Update(entity, imageProduct))
+            {
+                slidersRepository.SaveTranslations(slider);
                 return RedirectToAction("Index");
             }
             else
             {
                 ViewBag.Message = "هنگام عملیات خطایی رخ داد لطفا مجددا تلاش کنید";
-                var content = slidersRepository.GetByID(slider.SliderId);
+                var content = slidersRepository.GetForEdit(slider.SliderId);
                 return View(content);
             }
         }

--- a/Twelve/Areas/Admin/Views/AboutUsArticles/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/AboutUsArticles/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.AboutUsArticle
+﻿@model ViewModels.AboutUsArticleCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -14,17 +14,69 @@
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" id="Title" placeholder="عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="SubTitle">زیر عنوان</label>
-                                <input type="text" name="SubTitle" class="form-control" id="SubTitle" placeholder="زیر عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="Description">توضیح تکمیلی</label>
-                                <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="توضیح تکمیلی را وارد کنید"></textarea>
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="Title">عنوان</label>
+                                        <input type="text" name="Title" class="form-control" id="Title" value="@Model?.Title" placeholder="عنوان را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="SubTitle">زیر عنوان</label>
+                                        <input type="text" name="SubTitle" class="form-control" id="SubTitle" value="@Model?.SubTitle" placeholder="زیر عنوان را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="Description">توضیح تکمیلی</label>
+                                        <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="توضیح تکمیلی را وارد کنید">@Model?.Description</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleEn">Title</label>
+                                        <input type="text" name="TitleEn" class="form-control" id="TitleEn" value="@Model?.TitleEn" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="SubTitleEn">Subtitle</label>
+                                        <input type="text" name="SubTitleEn" class="form-control" id="SubTitleEn" value="@Model?.SubTitleEn" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="DescriptionEn">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="DescriptionEn" id="DescriptionEn">@Model?.DescriptionEn</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleAr">Title</label>
+                                        <input type="text" name="TitleAr" class="form-control" id="TitleAr" value="@Model?.TitleAr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="SubTitleAr">Subtitle</label>
+                                        <input type="text" name="SubTitleAr" class="form-control" id="SubTitleAr" value="@Model?.SubTitleAr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="DescriptionAr">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="DescriptionAr" id="DescriptionAr">@Model?.DescriptionAr</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleUr">Title</label>
+                                        <input type="text" name="TitleUr" class="form-control" id="TitleUr" value="@Model?.TitleUr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="SubTitleUr">Subtitle</label>
+                                        <input type="text" name="SubTitleUr" class="form-control" id="SubTitleUr" value="@Model?.SubTitleUr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="DescriptionUr">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="DescriptionUr" id="DescriptionUr">@Model?.DescriptionUr</textarea>
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">

--- a/Twelve/Areas/Admin/Views/AboutUsArticles/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/AboutUsArticles/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.AboutUsArticle
+﻿@model ViewModels.AboutUsArticleCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -16,17 +16,69 @@
                         <input type="hidden" name="AboutUsArticleId" id="AboutUsArticleId" value="@Model.AboutUsArticleId" />
                         <input type="hidden" name="ImageName" id="ImageName" value="@Model.ImageName" />
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" value="@Model.Title" id="Title" placeholder="عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="SubTitle">زیر عنوان</label>
-                                <input type="text" name="SubTitle" class="form-control" value="@Model.SubTitle" id="SubTitle" placeholder="زیر عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="Description">توضیح تکمیلی</label>
-                                <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="توضیح تکمیلی را وارد کنید">@Model.Description</textarea>
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="Title">عنوان</label>
+                                        <input type="text" name="Title" class="form-control" id="Title" value="@Model.Title" placeholder="عنوان را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="SubTitle">زیر عنوان</label>
+                                        <input type="text" name="SubTitle" class="form-control" id="SubTitle" value="@Model.SubTitle" placeholder="زیر عنوان را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="Description">توضیح تکمیلی</label>
+                                        <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="توضیح تکمیلی را وارد کنید">@Model.Description</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleEn">Title</label>
+                                        <input type="text" name="TitleEn" class="form-control" id="TitleEn" value="@Model.TitleEn" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="SubTitleEn">Subtitle</label>
+                                        <input type="text" name="SubTitleEn" class="form-control" id="SubTitleEn" value="@Model.SubTitleEn" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="DescriptionEn">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="DescriptionEn" id="DescriptionEn">@Model.DescriptionEn</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleAr">Title</label>
+                                        <input type="text" name="TitleAr" class="form-control" id="TitleAr" value="@Model.TitleAr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="SubTitleAr">Subtitle</label>
+                                        <input type="text" name="SubTitleAr" class="form-control" id="SubTitleAr" value="@Model.SubTitleAr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="DescriptionAr">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="DescriptionAr" id="DescriptionAr">@Model.DescriptionAr</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleUr">Title</label>
+                                        <input type="text" name="TitleUr" class="form-control" id="TitleUr" value="@Model.TitleUr" />
+                                    </div>
+                                <div class="form-group">
+                                        <label for="SubTitleUr">Subtitle</label>
+                                        <input type="text" name="SubTitleUr" class="form-control" id="SubTitleUr" value="@Model.SubTitleUr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="DescriptionUr">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="DescriptionUr" id="DescriptionUr">@Model.DescriptionUr</textarea>
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">

--- a/Twelve/Areas/Admin/Views/AboutUsItems/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/AboutUsItems/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.AboutUsItem
+﻿@model ViewModels.AboutUsItemCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -14,13 +14,53 @@
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="ItemTitle">عنوان</label>
-                                <input type="text" name="ItemTitle" class="form-control" id="ItemTitle" placeholder="عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="ItemDescription">توضیح تکمیلی</label>
-                                <textarea rows="5" class="form-control w-100" name="ItemDescription" id="ItemDescription" placeholder="توضیح تکمیلی را وارد کنید"></textarea>
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="ItemTitle">عنوان</label>
+                                        <input type="text" name="ItemTitle" class="form-control" id="ItemTitle" value="@Model?.ItemTitle" placeholder="عنوان را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ItemDescription">توضیح تکمیلی</label>
+                                        <textarea rows="5" class="form-control w-100" name="ItemDescription" id="ItemDescription" placeholder="توضیح تکمیلی را وارد کنید">@Model?.ItemDescription</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="ItemTitleEn">Title</label>
+                                        <input type="text" name="ItemTitleEn" class="form-control" id="ItemTitleEn" value="@Model?.ItemTitleEn" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ItemDescriptionEn">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="ItemDescriptionEn" id="ItemDescriptionEn">@Model?.ItemDescriptionEn</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="ItemTitleAr">Title</label>
+                                        <input type="text" name="ItemTitleAr" class="form-control" id="ItemTitleAr" value="@Model?.ItemTitleAr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ItemDescriptionAr">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="ItemDescriptionAr" id="ItemDescriptionAr">@Model?.ItemDescriptionAr</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="ItemTitleUr">Title</label>
+                                        <input type="text" name="ItemTitleUr" class="form-control" id="ItemTitleUr" value="@Model?.ItemTitleUr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ItemDescriptionUr">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="ItemDescriptionUr" id="ItemDescriptionUr">@Model?.ItemDescriptionUr</textarea>
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">

--- a/Twelve/Areas/Admin/Views/AboutUsItems/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/AboutUsItems/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.AboutUsItem
+﻿@model ViewModels.AboutUsItemCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -16,13 +16,53 @@
                         <input type="hidden" name="AboutUsItemId" id="AboutUsItemId" value="@Model.AboutUsItemId" />
                         <input type="hidden" name="ImageName" id="ImageName" value="@Model.ImageName" />
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="ItemTitle">عنوان</label>
-                                <input type="text" name="ItemTitle" class="form-control" value="@Model.ItemTitle" id="ItemTitle" placeholder="عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="ItemDescription">توضیح تکمیلی</label>
-                                <textarea rows="5" class="form-control w-100" name="ItemDescription" id="ItemDescription" placeholder="توضیح تکمیلی را وارد کنید">@Model.ItemDescription</textarea>
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="ItemTitle">عنوان</label>
+                                        <input type="text" name="ItemTitle" class="form-control" value="@Model.ItemTitle" id="ItemTitle" placeholder="عنوان را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ItemDescription">توضیح تکمیلی</label>
+                                        <textarea rows="5" class="form-control w-100" name="ItemDescription" id="ItemDescription" placeholder="توضیح تکمیلی را وارد کنید">@Model.ItemDescription</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="ItemTitleEn">Title</label>
+                                        <input type="text" name="ItemTitleEn" class="form-control" id="ItemTitleEn" value="@Model.ItemTitleEn" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ItemDescriptionEn">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="ItemDescriptionEn" id="ItemDescriptionEn">@Model.ItemDescriptionEn</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="ItemTitleAr">Title</label>
+                                        <input type="text" name="ItemTitleAr" class="form-control" id="ItemTitleAr" value="@Model.ItemTitleAr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ItemDescriptionAr">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="ItemDescriptionAr" id="ItemDescriptionAr">@Model.ItemDescriptionAr</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="ItemTitleUr">Title</label>
+                                        <input type="text" name="ItemTitleUr" class="form-control" id="ItemTitleUr" value="@Model.ItemTitleUr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ItemDescriptionUr">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="ItemDescriptionUr" id="ItemDescriptionUr">@Model.ItemDescriptionUr</textarea>
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">

--- a/Twelve/Areas/Admin/Views/AboutUsSight/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/AboutUsSight/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.AboutUsSight
+﻿@model ViewModels.AboutUsSightCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -14,13 +14,53 @@
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="SightTitle">عنوان</label>
-                                <input type="text" name="SightTitle" class="form-control" id="SightTitle" placeholder="عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="SightDescription">توضیح تکمیلی</label>
-                                <textarea rows="5" class="form-control w-100" name="SightDescription" id="SightDescription" placeholder="توضیح تکمیلی را وارد کنید"></textarea>
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="SightTitle">عنوان</label>
+                                        <input type="text" name="SightTitle" class="form-control" id="SightTitle" value="@Model?.SightTitle" placeholder="عنوان را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="SightDescription">توضیح تکمیلی</label>
+                                        <textarea rows="5" class="form-control w-100" name="SightDescription" id="SightDescription" placeholder="توضیح تکمیلی را وارد کنید">@Model?.SightDescription</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="SightTitleEn">Title</label>
+                                        <input type="text" name="SightTitleEn" class="form-control" id="SightTitleEn" value="@Model?.SightTitleEn" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="SightDescriptionEn">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="SightDescriptionEn" id="SightDescriptionEn">@Model?.SightDescriptionEn</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="SightTitleAr">Title</label>
+                                        <input type="text" name="SightTitleAr" class="form-control" id="SightTitleAr" value="@Model?.SightTitleAr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="SightDescriptionAr">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="SightDescriptionAr" id="SightDescriptionAr">@Model?.SightDescriptionAr</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="SightTitleUr">Title</label>
+                                        <input type="text" name="SightTitleUr" class="form-control" id="SightTitleUr" value="@Model?.SightTitleUr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="SightDescriptionUr">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="SightDescriptionUr" id="SightDescriptionUr">@Model?.SightDescriptionUr</textarea>
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">

--- a/Twelve/Areas/Admin/Views/AboutUsSight/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/AboutUsSight/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.AboutUsSight
+﻿@model ViewModels.AboutUsSightCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -16,13 +16,53 @@
                         <input type="hidden" name="AboutUsSightId" id="AboutUsSightId" value="@Model.AboutUsSightId" />
                         <input type="hidden" name="ImageName" id="ImageName" value="@Model.ImageName" />
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="SightTitle">عنوان</label>
-                                <input type="text" name="SightTitle" class="form-control" value="@Model.SightTitle" id="Title" placeholder="عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="SightDescription">توضیح تکمیلی</label>
-                                <textarea rows="5" class="form-control w-100" name="SightDescription" id="SightDescription" placeholder="توضیح تکمیلی را وارد کنید">@Model.SightDescription</textarea>
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="SightTitle">عنوان</label>
+                                        <input type="text" name="SightTitle" class="form-control" value="@Model.SightTitle" id="SightTitle" placeholder="عنوان را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="SightDescription">توضیح تکمیلی</label>
+                                        <textarea rows="5" class="form-control w-100" name="SightDescription" id="SightDescription" placeholder="توضیح تکمیلی را وارد کنید">@Model.SightDescription</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="SightTitleEn">Title</label>
+                                        <input type="text" name="SightTitleEn" class="form-control" id="SightTitleEn" value="@Model.SightTitleEn" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="SightDescriptionEn">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="SightDescriptionEn" id="SightDescriptionEn">@Model.SightDescriptionEn</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="SightTitleAr">Title</label>
+                                        <input type="text" name="SightTitleAr" class="form-control" id="SightTitleAr" value="@Model.SightTitleAr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="SightDescriptionAr">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="SightDescriptionAr" id="SightDescriptionAr">@Model.SightDescriptionAr</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="SightTitleUr">Title</label>
+                                        <input type="text" name="SightTitleUr" class="form-control" id="SightTitleUr" value="@Model.SightTitleUr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="SightDescriptionUr">Description</label>
+                                        <textarea rows="5" class="form-control w-100" name="SightDescriptionUr" id="SightDescriptionUr">@Model.SightDescriptionUr</textarea>
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">

--- a/Twelve/Areas/Admin/Views/Advertisements/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/Advertisements/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.Advertisement
+@model ViewModels.AdvertisementCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -14,9 +14,45 @@
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
                         <div class="card-body">
+                            <div class="row">
+                                <div class="col-12">
+                                    <ul class="nav nav-tabs" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" name="Title" class="form-control" id="Title" value="@Model?.Title" />
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model?.TitleEn" />
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model?.TitleAr" />
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model?.TitleUr" />
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                             <div class="form-group">
                                 <label for="Link">لینک</label>
-                                <input type="text" class="form-control" asp-for="Link" name="Link" id="Link" placeholder=" لینک را وارد کنید">
+                                <input type="text" class="form-control" name="Link" id="Link" value="@Model?.Link" placeholder=" لینک را وارد کنید">
                                 @Html.ValidationMessageFor(model => model.Link,"", new { @class = "text-danger" })
                             </div>
                             <div class="form-group ">

--- a/Twelve/Areas/Admin/Views/Advertisements/Index.cshtml
+++ b/Twelve/Areas/Admin/Views/Advertisements/Index.cshtml
@@ -19,6 +19,7 @@
                                     <tbody>
                                         <tr>
                                             <th>تصویر</th>
+                                            <th>عنوان</th>
                                             <th>لینک</th>
                                             <th>*</th>
                                         </tr>
@@ -26,6 +27,7 @@
                                         {
                                             <tr>
                                                 <td><img src="/Images/Ads/@item.ImageName" width="200" height="100" /></td>
+                                                <td>@item.Title</td>
                                                 <td>@item.Link</td>
                                                 <td>
                                                     <a href="/Admin/Advertisements/Update/@item.AdvertisementID" class="btn btn-outline-warning rounded mx-1" title="ویرایش">

--- a/Twelve/Areas/Admin/Views/Advertisements/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/Advertisements/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.Advertisement
+@model ViewModels.AdvertisementCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -15,11 +15,46 @@
                     <form role="form" method="post" enctype="multipart/form-data">
                         <input type="hidden" name="AdvertisementId" id="AdvertisementId" value="@Model.AdvertisementId" />
                         <input type="hidden" name="ImageName" id="ImageName" value="@Model.ImageName" />
-                        <input type="hidden" name="Title" id="Title" value="@Model.Title" />
                         <div class="card-body">
+                            <div class="row">
+                                <div class="col-12">
+                                    <ul class="nav nav-tabs" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" name="Title" class="form-control" value="@Model.Title" id="Title" />
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model?.TitleEn" />
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model?.TitleAr" />
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model?.TitleUr" />
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                             <div class="form-group">
                                 <label for="Link">لینک</label>
-                                <input type="text" class="form-control" name="Link" value="@Model.Link" id="Link" placeholder=" لینک را وارد کنید">
+                                <input type="text" class="form-control" name="Link" value="@Model.Link" id="Link" placeholder="لینک را وارد کنید">
                                 @Html.ValidationMessageFor(model => model.Link, "", new { @class = "text-danger" })
                             </div>
                             <div class="form-group ">

--- a/Twelve/Areas/Admin/Views/Blog/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/Blog/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model ViewModels.BlogCrudViewModel
+@model ViewModels.BlogCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -16,21 +16,72 @@
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-9">
-                                    <div class="form-group">
-                                        <label for="Title">عنوان</label>
-                                        <input type="text" class="form-control w-100" name="Title" id="Title" placeholder="عنوان را وارد کنید"/>
-                                        @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="ShortDescription">توضیح کوتاه</label>
-                                        <textarea rows="5" class="form-control w-100" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید"></textarea>
-                                        @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
-
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="Description">متن</label>
-                                        <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="متن را وارد کنید"></textarea>
-                                        @Html.ValidationMessageFor(model => model.Description, "", new { @class = "text-danger" })
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" class="form-control w-100" name="Title" id="Title" placeholder="عنوان را وارد کنید" />
+                                                @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescription">توضیح کوتاه</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید"></textarea>
+                                                @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="Description">متن</label>
+                                                <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="متن را وارد کنید"></textarea>
+                                                @Html.ValidationMessageFor(model => model.Description, "", new { @class = "text-danger" })
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleEn" id="TitleEn" value="@Model?.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionEn">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionEn" id="ShortDescriptionEn">@Model?.ShortDescriptionEn</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionEn">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionEn" id="DescriptionEn">@Model?.DescriptionEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleAr" id="TitleAr" value="@Model?.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionAr">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionAr" id="ShortDescriptionAr">@Model?.ShortDescriptionAr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionAr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionAr" id="DescriptionAr">@Model?.DescriptionAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleUr" id="TitleUr" value="@Model?.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionUr">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionUr" id="ShortDescriptionUr">@Model?.ShortDescriptionUr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionUr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionUr" id="DescriptionUr">@Model?.DescriptionUr</textarea>
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="form-group ">
                                         <div class="text-center">
@@ -53,7 +104,7 @@
                                     </div>
                                     <div class="form-group">
                                         <label for="StudyTime">زمان مطالعه (دقیقه)</label>
-                                        <input type="number" min="1" value="1" class="form-control w-100" name="StudyTime" id="StudyTime"  />
+                                        <input type="number" min="1" value="1" class="form-control w-100" name="StudyTime" id="StudyTime" />
                                     </div>
                                     <div class="form-check">
                                         @Html.CheckBoxFor(model => model.IsSlider,htmlAttributes: new {@class="form-check-input"})
@@ -71,7 +122,7 @@
                                         @foreach (var item in Model.Groups)
                                         {
                                             <div class="form-check m-2">
-                                                <input type="checkbox" class="form-check-input" id="@item.GroupID" name="SelectedGroups" value="@item.GroupID">
+                                                <input type="checkbox" class="form-check-input" id="@item.GroupID" @((Model.SelectedGroups != null && Model.SelectedGroups.Any(s => s == item.GroupID) ? "checked" : "")) name="SelectedGroups" value="@item.GroupID">
                                                 <label class="form-check-label" for="@item.GroupID">@item.GroupName</label>
                                             </div>
                                         }
@@ -96,6 +147,9 @@
     <script>
         $(function () {
             $('#Description').ckeditor();
+            $('#DescriptionEn').ckeditor();
+            $('#DescriptionAr').ckeditor();
+            $('#DescriptionUr').ckeditor();
         });
     </script>
 }

--- a/Twelve/Areas/Admin/Views/Blog/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/Blog/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model ViewModels.BlogCrudViewModel
+@model ViewModels.BlogCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -18,17 +18,69 @@
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-9">
-                                    <div class="form-group">
-                                        <label for="Title">عنوان</label>
-                                        <input type="text" class="form-control w-100" value="@Model.Title"  name="Title" id="Title" placeholder="عنوان را وارد کنید" />
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="ShortDescription">توضیح کوتاه</label>
-                                        <textarea rows="5" class="form-control w-100" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">@Model.ShortDescription</textarea>
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="Description">متن</label>
-                                        <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="متن را وارد کنید">@Model.Description</textarea>
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" class="form-control w-100" value="@Model.Title" name="Title" id="Title" placeholder="عنوان را وارد کنید" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescription">توضیح کوتاه</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">@Model.ShortDescription</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="Description">متن</label>
+                                                <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="متن را وارد کنید">@Model.Description</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleEn" id="TitleEn" value="@Model.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionEn">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionEn" id="ShortDescriptionEn">@Model.ShortDescriptionEn</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionEn">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionEn" id="DescriptionEn">@Model.DescriptionEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleAr" id="TitleAr" value="@Model.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionAr">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionAr" id="ShortDescriptionAr">@Model.ShortDescriptionAr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionAr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionAr" id="DescriptionAr">@Model.DescriptionAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleUr" id="TitleUr" value="@Model.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionUr">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="ShortDescriptionUr" id="ShortDescriptionUr">@Model.ShortDescriptionUr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionUr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionUr" id="DescriptionUr">@Model.DescriptionUr</textarea>
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="form-group ">
                                         <div class="text-center">
@@ -78,7 +130,6 @@
                             </div>
                         </div>
                         <!-- /.card-body -->
-
                         <div class="card-footer">
                             <button type="submit" class="btn btn-warning">ثبت</button>
                             <a href="/Admin/Blog" class="btn btn-info float-left">بازگشت به لیست</a>
@@ -94,6 +145,9 @@
     <script>
         $(function () {
             $('#Description').ckeditor();
+            $('#DescriptionEn').ckeditor();
+            $('#DescriptionAr').ckeditor();
+            $('#DescriptionUr').ckeditor();
         });
     </script>
 }

--- a/Twelve/Areas/Admin/Views/BlogGroups/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/BlogGroups/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.BlogGroup
+@model ViewModels.BlogGroupCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -10,25 +10,48 @@
                             <span class="text-dark mx-2">@ViewBag.Message</span>
                         </h3>
                     </div>
-                    <!-- /.card-header -->
-                    <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="GroupName">عنوان</label>
-                                <input type="text" name="GroupName" class="form-control" id="GroupName" placeholder="عنوان را وارد کنید">
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupName">عنوان</label>
+                                        <input type="text" name="GroupName" class="form-control" id="GroupName" value="@Model.GroupName" placeholder="عنوان را وارد کنید" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameEn">Title</label>
+                                        <input type="text" name="GroupNameEn" class="form-control" id="GroupNameEn" value="@Model.GroupNameEn" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameAr">Title</label>
+                                        <input type="text" name="GroupNameAr" class="form-control" id="GroupNameAr" value="@Model.GroupNameAr" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameUr">Title</label>
+                                        <input type="text" name="GroupNameUr" class="form-control" id="GroupNameUr" value="@Model.GroupNameUr" />
+                                    </div>
+                                </div>
                             </div>
                         </div>
-                        <!-- /.card-body -->
-
                         <div class="card-footer">
                             <button type="submit" class="btn btn-success">ثبت</button>
                             <a href="/Admin/BlogGroups" class="btn btn-info float-left">بازگشت به لیست</a>
                         </div>
                     </form>
                 </div>
-                <!-- /.card -->
             </div>
         </div>
-    </div><!-- /.container-fluid -->
+    </div>
 </div>

--- a/Twelve/Areas/Admin/Views/BlogGroups/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/BlogGroups/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.BlogGroup
+@model ViewModels.BlogGroupCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -10,27 +10,50 @@
                             <span class="text-dark mx-2">@ViewBag.Message</span>
                         </h3>
                     </div>
-                    <!-- /.card-header -->
-                    <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
                         @Html.HiddenFor(m => m.BlogGroupId)
                         @Html.HiddenFor(m => m.ParentId)
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="GroupName">عنوان</label>
-                                <input type="text" name="GroupName" class="form-control" value="@Model.GroupName" id="GroupName" placeholder="عنوان را وارد کنید">
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupName">عنوان</label>
+                                        <input type="text" name="GroupName" class="form-control" id="GroupName" value="@Model.GroupName" placeholder="عنوان را وارد کنید" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameEn">Title</label>
+                                        <input type="text" name="GroupNameEn" class="form-control" id="GroupNameEn" value="@Model.GroupNameEn" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameAr">Title</label>
+                                        <input type="text" name="GroupNameAr" class="form-control" id="GroupNameAr" value="@Model.GroupNameAr" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameUr">Title</label>
+                                        <input type="text" name="GroupNameUr" class="form-control" id="GroupNameUr" value="@Model.GroupNameUr" />
+                                    </div>
+                                </div>
                             </div>
                         </div>
-                        <!-- /.card-body -->
-
                         <div class="card-footer">
                             <button type="submit" class="btn btn-warning">ثبت</button>
                             <a href="/Admin/BlogGroups" class="btn btn-info float-left">بازگشت به لیست</a>
                         </div>
                     </form>
                 </div>
-                <!-- /.card -->
             </div>
         </div>
-    </div><!-- /.container-fluid -->
+    </div>
 </div>

--- a/Twelve/Areas/Admin/Views/CallInfo/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/CallInfo/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.CallInfo
+@model ViewModels.CallInfoCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -14,17 +14,73 @@
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" id="Title" placeholder="عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="ShortDescription">توضیح کوتاه</label>
-                                <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="Description">توضیح تکمیلی</label>
-                                <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="توضیح تکمیلی را وارد کنید"></textarea>
+                            <div class="row">
+                                <div class="col-12">
+                                    <ul class="nav nav-tabs" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" name="Title" class="form-control" id="Title" value="@Model?.Title" placeholder="عنوان را وارد کنید">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescription">توضیح کوتاه</label>
+                                                <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" value="@Model?.ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="Description">توضیح تکمیلی</label>
+                                                <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="توضیح تکمیلی را وارد کنید">@Model?.Description</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model?.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionEn">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionEn" id="ShortDescriptionEn" value="@Model?.ShortDescriptionEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionEn">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionEn" id="DescriptionEn">@Model?.DescriptionEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model?.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionAr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionAr" id="ShortDescriptionAr" value="@Model?.ShortDescriptionAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionAr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionAr" id="DescriptionAr">@Model?.DescriptionAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model?.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionUr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionUr" id="ShortDescriptionUr" value="@Model?.ShortDescriptionUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionUr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionUr" id="DescriptionUr">@Model?.DescriptionUr</textarea>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">

--- a/Twelve/Areas/Admin/Views/CallInfo/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/CallInfo/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.CallInfo
+@model ViewModels.CallInfoCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -16,17 +16,73 @@
                         <input type="hidden" name="CallInfoId" id="CallInfoId" value="@Model.CallInfoId" />
                         <input type="hidden" name="ImageName" id="ImageName" value="@Model.ImageName" />
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" value="@Model.Title" id="Title" placeholder="عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="ShortDescription">توضیح کوتاه</label>
-                                <input type="text" class="form-control" name="ShortDescription" value="@Model.ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="Description">توضیح تکمیلی</label>
-                                <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="توضیح تکمیلی را وارد کنید">@Model.Description</textarea>
+                            <div class="row">
+                                <div class="col-12">
+                                    <ul class="nav nav-tabs" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" name="Title" class="form-control" value="@Model.Title" id="Title" placeholder="عنوان را وارد کنید">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescription">توضیح کوتاه</label>
+                                                <input type="text" class="form-control" name="ShortDescription" value="@Model.ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="Description">توضیح تکمیلی</label>
+                                                <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="توضیح تکمیلی را وارد کنید">@Model.Description</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model?.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionEn">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionEn" id="ShortDescriptionEn" value="@Model?.ShortDescriptionEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionEn">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionEn" id="DescriptionEn">@Model?.DescriptionEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model?.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionAr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionAr" id="ShortDescriptionAr" value="@Model?.ShortDescriptionAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionAr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionAr" id="DescriptionAr">@Model?.DescriptionAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model?.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionUr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionUr" id="ShortDescriptionUr" value="@Model?.ShortDescriptionUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionUr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionUr" id="DescriptionUr">@Model?.DescriptionUr</textarea>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">

--- a/Twelve/Areas/Admin/Views/Faq/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/Faq/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model ViewModels.FaqsCrudViewModel
+@model ViewModels.FaqsCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -16,13 +16,53 @@
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-9">
-                                    <div class="form-group">
-                                        <label for="Question">سوال</label>
-                                        <textarea rows="5" class="form-control w-100" name="Question" id="Question" placeholder="سوال را وارد کنید"></textarea>
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="Answer">پاسخ</label>
-                                        <textarea rows="5" class="form-control w-100" name="Answer" id="Answer" placeholder="پاسخ را وارد کنید"></textarea>
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Question">سوال</label>
+                                                <textarea rows="5" class="form-control w-100" name="Question" id="Question" placeholder="سوال را وارد کنید"></textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="Answer">پاسخ</label>
+                                                <textarea rows="5" class="form-control w-100" name="Answer" id="Answer" placeholder="پاسخ را وارد کنید"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionEn">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionEn" id="QuestionEn"></textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerEn">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerEn" id="AnswerEn"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionAr">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionAr" id="QuestionAr"></textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerAr">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerAr" id="AnswerAr"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionUr">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionUr" id="QuestionUr"></textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerUr">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerUr" id="AnswerUr"></textarea>
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="form-check">
                                         @Html.CheckBoxFor(model => model.IsMain,htmlAttributes: new {@class="form-check-input"})
@@ -49,7 +89,6 @@
                             </div>
                         </div>
                         <!-- /.card-body -->
-
                         <div class="card-footer">
                             <button type="submit" class="btn btn-success">ثبت</button>
                             <a href="/Admin/Faq" class="btn btn-info float-left">بازگشت به لیست</a>

--- a/Twelve/Areas/Admin/Views/Faq/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/Faq/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model ViewModels.FaqsCrudViewModel
+@model ViewModels.FaqsCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -13,17 +13,57 @@
                     <!-- /.card-header -->
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
-                        @Html.HiddenFor(m=> m.FaqID)
+                        @Html.HiddenFor(m => m.FaqID)
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-9">
-                                    <div class="form-group">
-                                        <label for="Question">سوال</label>
-                                        <textarea rows="5" class="form-control w-100" name="Question" id="Question" placeholder="سوال را وارد کنید">@Model.Question</textarea>
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="Answer">پاسخ</label>
-                                        <textarea rows="5" class="form-control w-100" name="Answer" id="Answer" placeholder="پاسخ را وارد کنید">@Model.Answer</textarea>
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Question">سوال</label>
+                                                <textarea rows="5" class="form-control w-100" name="Question" id="Question" placeholder="سوال را وارد کنید">@Model.Question</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="Answer">پاسخ</label>
+                                                <textarea rows="5" class="form-control w-100" name="Answer" id="Answer" placeholder="پاسخ را وارد کنید">@Model.Answer</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionEn">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionEn" id="QuestionEn">@Model.QuestionEn</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerEn">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerEn" id="AnswerEn">@Model.AnswerEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionAr">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionAr" id="QuestionAr">@Model.QuestionAr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerAr">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerAr" id="AnswerAr">@Model.AnswerAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="QuestionUr">Question</label>
+                                                <textarea rows="5" class="form-control w-100" name="QuestionUr" id="QuestionUr">@Model.QuestionUr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="AnswerUr">Answer</label>
+                                                <textarea rows="5" class="form-control w-100" name="AnswerUr" id="AnswerUr">@Model.AnswerUr</textarea>
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="form-check">
                                         @Html.CheckBoxFor(model => model.IsMain,htmlAttributes: new {@class="form-check-input"})
@@ -41,7 +81,7 @@
                                         @foreach (var item in Model.Groups)
                                         {
                                             <div class="form-check m-2">
-                                                <input type="checkbox" class="form-check-input" id="@item.GroupID" @((Model.SelectedGroups.Any(s => s == item.GroupID) ? "checked" : "")) name="SelectedGroups" value="@item.GroupID">
+                                                <input type="checkbox" class="form-check-input" id="@item.GroupID" name="SelectedGroups" value="@item.GroupID">
                                                 <label class="form-check-label" for="@item.GroupID">@item.GroupName</label>
                                             </div>
                                         }
@@ -50,9 +90,8 @@
                             </div>
                         </div>
                         <!-- /.card-body -->
-
                         <div class="card-footer">
-                            <button type="submit" class="btn btn-success">ثبت</button>
+                            <button type="submit" class="btn btn-warning">ثبت</button>
                             <a href="/Admin/Faq" class="btn btn-info float-left">بازگشت به لیست</a>
                         </div>
                     </form>

--- a/Twelve/Areas/Admin/Views/FaqsGroup/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/FaqsGroup/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.FaqGroup
+﻿@model ViewModels.FaqGroupCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -14,9 +14,37 @@
                     <!-- form start -->
                     <form role="form" method="post">
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="GroupName">عنوان</label>
-                                <input type="text" name="GroupName" class="form-control" id="GroupName" placeholder="عنوان را وارد کنید">
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupName">عنوان</label>
+                                        <input type="text" name="GroupName" class="form-control" id="GroupName" value="@Model.GroupName" placeholder="عنوان را وارد کنید" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameEn">Title</label>
+                                        <input type="text" name="GroupNameEn" class="form-control" id="GroupNameEn" value="@Model.GroupNameEn" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameAr">Title</label>
+                                        <input type="text" name="GroupNameAr" class="form-control" id="GroupNameAr" value="@Model.GroupNameAr" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameUr">Title</label>
+                                        <input type="text" name="GroupNameUr" class="form-control" id="GroupNameUr" value="@Model.GroupNameUr" />
+                                    </div>
+                                </div>
                             </div>
                         </div>
                         <!-- /.card-body -->

--- a/Twelve/Areas/Admin/Views/FaqsGroup/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/FaqsGroup/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.FaqGroup
+﻿@model ViewModels.FaqGroupCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -16,9 +16,37 @@
                         @Html.HiddenFor(m=> m.FaqGroupId)
                         @Html.HiddenFor(m=> m.ParentId)
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="GroupName">عنوان</label>
-                                <input type="text" name="GroupName" class="form-control" value="@Model.GroupName" id="GroupName" placeholder="عنوان را وارد کنید">
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupName">عنوان</label>
+                                        <input type="text" name="GroupName" class="form-control" id="GroupName" value="@Model.GroupName" placeholder="عنوان را وارد کنید" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameEn">Title</label>
+                                        <input type="text" name="GroupNameEn" class="form-control" id="GroupNameEn" value="@Model.GroupNameEn" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameAr">Title</label>
+                                        <input type="text" name="GroupNameAr" class="form-control" id="GroupNameAr" value="@Model.GroupNameAr" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="GroupNameUr">Title</label>
+                                        <input type="text" name="GroupNameUr" class="form-control" id="GroupNameUr" value="@Model.GroupNameUr" />
+                                    </div>
+                                </div>
                             </div>
                         </div>
                         <!-- /.card-body -->

--- a/Twelve/Areas/Admin/Views/Features/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/Features/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.Feature
+@model ViewModels.FeatureCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -14,22 +14,76 @@
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" id="Title" placeholder="عنوان را وارد کنید">
-                                @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
-
-                            </div>
-                            <div class="form-group">
-                                <label for="ShortDescription">توضیح کوتاه</label>
-                                <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
-                                @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
-
-                            </div>
-                            <div class="form-group">
-                                <label for="FirstDescription">توضیح</label>
-                                <textarea rows="5" class="form-control w-100" name="FirstDescription" id="FirstDescription" placeholder="توضیح را وارد کنید"></textarea>
-                                @Html.ValidationMessageFor(model => model.FirstDescription, "", new { @class = "text-danger" })
+                            <div class="row">
+                                <div class="col-12">
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" name="Title" class="form-control" id="Title" value="@Model?.Title" placeholder="عنوان را وارد کنید">
+                                                @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescription">توضیح کوتاه</label>
+                                                <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" value="@Model?.ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                                                @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
+                                            </div>
+                        <div class="form-group">
+                                                <label for="FirstDescription">توضیح</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescription" id="FirstDescription" placeholder="توضیح را وارد کنید">@Model?.FirstDescription</textarea>
+                                                @Html.ValidationMessageFor(model => model.FirstDescription, "", new { @class = "text-danger" })
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model?.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionEn">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionEn" id="ShortDescriptionEn" value="@Model?.ShortDescriptionEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionEn">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionEn" id="FirstDescriptionEn">@Model?.FirstDescriptionEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model?.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionAr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionAr" id="ShortDescriptionAr" value="@Model?.ShortDescriptionAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionAr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionAr" id="FirstDescriptionAr">@Model?.FirstDescriptionAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model?.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionUr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionUr" id="ShortDescriptionUr" value="@Model?.ShortDescriptionUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionUr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionUr" id="FirstDescriptionUr">@Model?.FirstDescriptionUr</textarea>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">
@@ -67,11 +121,11 @@
                                 </div>
                                 <div class="form-group m-3">
                                     <label for="FirstArticleTitle">عنوان مقاله اول</label>
-                                    <input type="text" class="form-control" name="FirstArticleTitle" id="FirstArticleTitle" placeholder="عنوان مقاله اول را وارد کنید">
+                                    <input type="text" class="form-control" name="FirstArticleTitle" id="FirstArticleTitle" value="@Model?.FirstArticleTitle" placeholder="عنوان مقاله اول را وارد کنید">
                                 </div>
                                 <div class="form-group m-3">
                                     <label for="FirstArticleDescription">توضیح مقاله اول</label>
-                                    <textarea rows="5" class="form-control w-100" name="FirstArticleDescription" id="FirstArticleDescription" placeholder="توضیح مقاله اول را وارد کنید"></textarea>
+                                    <textarea rows="5" class="form-control w-100" name="FirstArticleDescription" id="FirstArticleDescription" placeholder="توضیح مقاله اول را وارد کنید">@Model?.FirstArticleDescription</textarea>
                                 </div>
                                 <div class="form-group m-3 ">
                                     <div class="text-center">
@@ -91,11 +145,11 @@
                                 </div>
                                 <div class="form-group m-3">
                                     <label for="SecondArticleTitle">عنوان مقاله دوم</label>
-                                    <input type="text" class="form-control" name="SecondArticleTitle" id="SecondArticleTitle" placeholder="عنوان مقاله دوم را وارد کنید">
+                                    <input type="text" class="form-control" name="SecondArticleTitle" id="SecondArticleTitle" value="@Model?.SecondArticleTitle" placeholder="عنوان مقاله دوم را وارد کنید">
                                 </div>
                                 <div class="form-group m-3">
                                     <label for="SecondArticleDescription">توضیح مقاله دوم</label>
-                                    <textarea rows="5" class="form-control w-100" name="SecondArticleDescription" id="SecondArticleDescription" placeholder="توضیح مقاله دوم را وارد کنید"></textarea>
+                                    <textarea rows="5" class="form-control w-100" name="SecondArticleDescription" id="SecondArticleDescription" placeholder="توضیح مقاله دوم را وارد کنید">@Model?.SecondArticleDescription</textarea>
                                 </div>
                                 <div class="form-group m-3 ">
                                     <div class="text-center">
@@ -109,8 +163,6 @@
                                     </div>
                                 </div>
                             </div>
-                            
-                            
                         </div>
                         <!-- /.card-body -->
 

--- a/Twelve/Areas/Admin/Views/Features/CreateItem.cshtml
+++ b/Twelve/Areas/Admin/Views/Features/CreateItem.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.FeatureItem
+@model ViewModels.FeatureItemCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -13,15 +13,55 @@
                     <!-- /.card-header -->
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
-                        <input type="hidden" name="FeatureID" value="@ViewBag.FeatureID" />
+                        <input type="hidden" name="FeatureId" value="@Model.FeatureId" />
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" id="Title" placeholder="عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="ShortDescription">توضیح کوتاه</label>
-                                <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="Title">عنوان</label>
+                                        <input type="text" name="Title" class="form-control" id="Title" value="@Model?.Title" placeholder="عنوان را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescription">توضیح کوتاه</label>
+                                        <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" value="@Model?.ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleEn">Title</label>
+                                        <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model?.TitleEn" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionEn">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionEn" id="ShortDescriptionEn" value="@Model?.ShortDescriptionEn" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleAr">Title</label>
+                                        <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model?.TitleAr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionAr">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionAr" id="ShortDescriptionAr" value="@Model?.ShortDescriptionAr" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleUr">Title</label>
+                                        <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model?.TitleUr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionUr">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionUr" id="ShortDescriptionUr" value="@Model?.ShortDescriptionUr" />
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">
@@ -39,7 +79,7 @@
 
                         <div class="card-footer">
                             <button type="submit" class="btn btn-success">ثبت</button>
-                            <a href="/Admin/Features/ShowItems/@ViewBag.FeatureID" class="btn btn-info float-left">بازگشت به لیست</a>
+                            <a href="/Admin/Features/ShowItems/@Model.FeatureId" class="btn btn-info float-left">بازگشت به لیست</a>
                         </div>
                     </form>
                 </div>

--- a/Twelve/Areas/Admin/Views/Features/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/Features/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.Feature
+@model ViewModels.FeatureCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -13,29 +13,83 @@
                     <!-- /.card-header -->
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
-                        @Html.HiddenFor(m => m.FeatureId)
-                        @Html.HiddenFor(m => m.ImageName)
-                        @Html.HiddenFor(m => m.AnimateFilename)
-                        @Html.HiddenFor(m => m.FirstArticleImage)
-                        @Html.HiddenFor(m => m.SecondArticleImage)
-                        @Html.HiddenFor(m => m.IntroduceImageName)
+                        <input type="hidden" name="FeatureId" value="@Model.FeatureId" />
+                        <input type="hidden" name="ImageName" value="@Model.ImageName" />
+                        <input type="hidden" name="AnimateFilename" value="@Model.AnimateFilename" />
+                        <input type="hidden" name="FirstArticleImage" value="@Model.FirstArticleImage" />
+                        <input type="hidden" name="SecondArticleImage" value="@Model.SecondArticleImage" />
+                        <input type="hidden" name="IntroduceImageName" value="@Model.IntroduceImageName" />
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" id="Title" value="@Model.Title" placeholder="عنوان را وارد کنید">
-                                @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
-                            </div>
-                            <div class="form-group">
-                                <label for="ShortDescription">توضیح کوتاه</label>
-                                <input type="text" class="form-control" name="ShortDescription" value="@Model.ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
-                                @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
-
-                            </div>
-                            <div class="form-group">
-                                <label for="FirstDescription">توضیح</label>
-                                <textarea rows="5" class="form-control w-100" name="FirstDescription" id="FirstDescription" placeholder="توضیح را وارد کنید">@Model.FirstDescription</textarea>
-                                @Html.ValidationMessageFor(model => model.FirstDescription, "", new { @class = "text-danger" })
-
+                            <div class="row">
+                                <div class="col-12">
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" name="Title" class="form-control" id="Title" value="@Model.Title" placeholder="عنوان را وارد کنید">
+                                                @Html.ValidationMessageFor(model => model.Title, "", new { @class = "text-danger" })
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescription">توضیح کوتاه</label>
+                                                <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" value="@Model.ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                                                @Html.ValidationMessageFor(model => model.ShortDescription, "", new { @class = "text-danger" })
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescription">توضیح</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescription" id="FirstDescription" placeholder="توضیح را وارد کنید">@Model.FirstDescription</textarea>
+                                                @Html.ValidationMessageFor(model => model.FirstDescription, "", new { @class = "text-danger" })
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionEn">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionEn" id="ShortDescriptionEn" value="@Model.ShortDescriptionEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionEn">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionEn" id="FirstDescriptionEn">@Model.FirstDescriptionEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionAr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionAr" id="ShortDescriptionAr" value="@Model.ShortDescriptionAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionAr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionAr" id="FirstDescriptionAr">@Model.FirstDescriptionAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionUr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionUr" id="ShortDescriptionUr" value="@Model.ShortDescriptionUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="FirstDescriptionUr">Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="FirstDescriptionUr" id="FirstDescriptionUr">@Model.FirstDescriptionUr</textarea>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">
@@ -81,7 +135,7 @@
                                 </div>
                                 <div class="form-group m-3 ">
                                     <div class="text-center">
-                                        <img id="imageFAPreview" class="thumbnail w-100 my-5" src="~/Images/Features/@Model.FirstArticleImage" />
+                                        <img id="imageFAPreview" class="thumbnail my-5 w-100" src="~/Images/Features/@Model.FirstArticleImage" />
                                     </div>
                                     <div class="form-group">
                                         <div class="col-md-10">
@@ -105,7 +159,7 @@
                                 </div>
                                 <div class="form-group m-3 ">
                                     <div class="text-center">
-                                        <img id="imageSAPreview" class="thumbnail w-100 my-5" src="~/Images/Features/@Model.SecondArticleImage" />
+                                        <img id="imageSAPreview" class="thumbnail my-5 w-100" src="~/Images/Features/@Model.SecondArticleImage" />
                                     </div>
                                     <div class="form-group">
                                         <div class="col-md-10">
@@ -115,11 +169,8 @@
                                     </div>
                                 </div>
                             </div>
-
-
                         </div>
                         <!-- /.card-body -->
-
                         <div class="card-footer">
                             <button type="submit" class="btn btn-warning">ثبت</button>
                             <a href="/Admin/Features" class="btn btn-info float-left">بازگشت به لیست</a>
@@ -131,12 +182,12 @@
         </div>
     </div><!-- /.container-fluid -->
 </div>
-@section Ckeditor {
-    <script>
-        $(function () {
-            $('#FirstDescription').ckeditor();
-        });
-    </script>
+@section Ckeditor{
+<script>
+    $(function () {
+        $('#FirstDescription').ckeditor();
+    });
+</script>
 }
 <script>
     imageProduct.onchange = evt => {

--- a/Twelve/Areas/Admin/Views/Features/UpdateItem.cshtml
+++ b/Twelve/Areas/Admin/Views/Features/UpdateItem.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.FeatureItem
+@model ViewModels.FeatureItemCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -13,17 +13,57 @@
                     <!-- /.card-header -->
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
-                        <input type="hidden" name="FeaturesItemId" id="FeaturesItemId" value="@Model.FeaturesItemId" />
-                        <input type="hidden" name="ImageName" id="ImageName" value="@Model.ImageName" />
-                        <input type="hidden" name="FeatureId" id="FeatureId" value="@Model.FeatureId" />
+                        <input type="hidden" name="FeaturesItemId" value="@Model.FeaturesItemId" />
+                        <input type="hidden" name="ImageName" value="@Model.ImageName" />
+                        <input type="hidden" name="FeatureId" value="@Model.FeatureId" />
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" value="@Model.Title" id="Title" placeholder="عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="ShortDescription">توضیح کوتاه</label>
-                                <input type="text" class="form-control" name="ShortDescription" value="@Model.ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="Title">عنوان</label>
+                                        <input type="text" name="Title" class="form-control" id="Title" value="@Model.Title" placeholder="عنوان را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescription">توضیح کوتاه</label>
+                                        <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" value="@Model.ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleEn">Title</label>
+                                        <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model.TitleEn" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionEn">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionEn" id="ShortDescriptionEn" value="@Model.ShortDescriptionEn" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleAr">Title</label>
+                                        <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model.TitleAr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionAr">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionAr" id="ShortDescriptionAr" value="@Model.ShortDescriptionAr" />
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="TitleUr">Title</label>
+                                        <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model.TitleUr" />
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="ShortDescriptionUr">Short Description</label>
+                                        <input type="text" class="form-control" name="ShortDescriptionUr" id="ShortDescriptionUr" value="@Model.ShortDescriptionUr" />
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">

--- a/Twelve/Areas/Admin/Views/Home/AboutUsContent.cshtml
+++ b/Twelve/Areas/Admin/Views/Home/AboutUsContent.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.AboutUsContent
+@model ViewModels.AboutUsContentCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -19,17 +19,245 @@
                                 <input type="hidden" name="ImageName" id="ImageName" value="@Model.ImageName" />
                                 <input type="hidden" name="DownloadImageName" id="DownloadImageName" value="@Model.DownloadImageName" />
                                 <div class="card-body">
-                                    <div class="form-group">
-                                        <label for="Title">عنوان هدر</label>
-                                        <input type="text" name="Title" class="form-control" value="@Model.Title" id="Title" placeholder="عنوان هدر را وارد کنید">
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="SubTitle">زیر عنوان هدر</label>
-                                        <input type="text" class="form-control" name="SubTitle" value="@Model.SubTitle" id="SubTitle" placeholder="زیر عنوان هدر را وارد کنید">
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="Description">توضیحات هدر</label>
-                                        <textarea rows="5" name="Description" class="form-control w-100" name="Description">@Model.Description</textarea>
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان هدر</label>
+                                                <input type="text" name="Title" class="form-control" value="@Model.Title" id="Title" placeholder="عنوان هدر را وارد کنید">
+                                            </div>
+                        <div class="form-group">
+                                                <label for="SubTitle">زیر عنوان هدر</label>
+                                                <input type="text" class="form-control" name="SubTitle" value="@Model.SubTitle" id="SubTitle" placeholder="زیر عنوان هدر را وارد کنید">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="Description">توضیحات هدر</label>
+                                                <textarea rows="5" name="Description" class="form-control w-100">@Model.Description</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="SecondTitle">عنوان ویژگی های نرم افزار</label>
+                                                <input type="text" name="SecondTitle" class="form-control" value="@Model.SecondTitle" id="SecondTitle" placeholder="عنوان ویژگی های نرم افزار را وارد کنید">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="SecondSubTitle">زیر عنوان ویژگی های نرم افزار</label>
+                                                <input type="text" class="form-control" name="SecondSubTitle" value="@Model.SecondSubTitle" id="SecondSubTitle" placeholder="زیر عنوان ویژگی های نرم افزار را وارد کنید">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="SecondDescription">توضیحات ویژگی های نرم افزار</label>
+                                                <textarea rows="5" name="SecondDescription" class="form-control w-100">@Model.SecondDescription</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ThirdTitle">عنوان سوالات متداول</label>
+                                                <input type="text" name="ThirdTitle" class="form-control" value="@Model.ThirdTitle" id="ThirdTitle" placeholder="عنوان سوالات مداول را وارد کنید">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ThirdSubTitle">زیر عنوان سوالات متداول</label>
+                                                <input type="text" class="form-control" name="ThirdSubTitle" value="@Model.ThirdSubTitle" id="ThirdSubTitle" placeholder="زیر عنوان سوالات متداول را وارد کنید">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ForthTitle">عنوان پاراگراف پایین دانلود باکس</label>
+                                                <input type="text" name="ForthTitle" class="form-control" value="@Model.ForthTitle" id="ForthTitle" placeholder="عنوان پاراگراف پایین دانلود باکس را وارد کنید">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ForthSubTitle">زیر عنوان پاراگراف پایین دانلود باکس</label>
+                                                <input type="text" class="form-control" name="ForthSubTitle" value="@Model.ForthSubTitle" id="ForthSubTitle" placeholder="زیر عنوان پاراگراف پایین دانلود باکس را وارد کنید">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ForthDescription">توضیحات پاراگراف پایین دانلود باکس</label>
+                                                <textarea rows="5" name="ForthDescription" class="form-control w-100">@Model.ForthDescription</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="LogoTitle">عنوان بخش لوگو</label>
+                                                <input type="text" name="LogoTitle" class="form-control" value="@Model.LogoTitle" id="LogoTitle" placeholder="عنوان بخش لوگو را وارد کنید">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="LogoSubTitle">زیر عنوان بخش لوگو</label>
+                                                <input type="text" class="form-control" name="LogoSubTitle" value="@Model.LogoSubTitle" id="LogoSubTitle" placeholder="زیر عنوان بخش لوگو را وارد کنید">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="LogoDescription">توضیحات بخش لوگو</label>
+                                                <textarea rows="5" name="LogoDescription" class="form-control w-100">@Model.LogoDescription</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Header Title</label>
+                                                <input type="text" name="TitleEn" class="form-control" value="@Model.TitleEn" id="TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="SubTitleEn">Header Subtitle</label>
+                                                <input type="text" class="form-control" name="SubTitleEn" value="@Model.SubTitleEn" id="SubTitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionEn">Header Description</label>
+                                                <textarea rows="5" name="DescriptionEn" class="form-control w-100">@Model.DescriptionEn</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="SecondTitleEn">Feature Title</label>
+                                                <input type="text" name="SecondTitleEn" class="form-control" value="@Model.SecondTitleEn" id="SecondTitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="SecondSubTitleEn">Feature Subtitle</label>
+                                                <input type="text" class="form-control" name="SecondSubTitleEn" value="@Model.SecondSubTitleEn" id="SecondSubTitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="SecondDescriptionEn">Feature Description</label>
+                                                <textarea rows="5" name="SecondDescriptionEn" class="form-control w-100">@Model.SecondDescriptionEn</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ThirdTitleEn">FAQ Title</label>
+                                                <input type="text" name="ThirdTitleEn" class="form-control" value="@Model.ThirdTitleEn" id="ThirdTitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ThirdSubTitleEn">FAQ Subtitle</label>
+                                                <input type="text" class="form-control" name="ThirdSubTitleEn" value="@Model.ThirdSubTitleEn" id="ThirdSubTitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ForthTitleEn">Bottom Paragraph Title</label>
+                                                <input type="text" name="ForthTitleEn" class="form-control" value="@Model.ForthTitleEn" id="ForthTitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ForthSubTitleEn">Bottom Paragraph Subtitle</label>
+                                                <input type="text" class="form-control" name="ForthSubTitleEn" value="@Model.ForthSubTitleEn" id="ForthSubTitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ForthDescriptionEn">Bottom Paragraph Description</label>
+                                                <textarea rows="5" name="ForthDescriptionEn" class="form-control w-100">@Model.ForthDescriptionEn</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="LogoTitleEn">Logo Title</label>
+                                                <input type="text" name="LogoTitleEn" class="form-control" value="@Model.LogoTitleEn" id="LogoTitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="LogoSubTitleEn">Logo Subtitle</label>
+                                                <input type="text" class="form-control" name="LogoSubTitleEn" value="@Model.LogoSubTitleEn" id="LogoSubTitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="LogoDescriptionEn">Logo Description</label>
+                                                <textarea rows="5" name="LogoDescriptionEn" class="form-control w-100">@Model.LogoDescriptionEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Header Title</label>
+                                                <input type="text" name="TitleAr" class="form-control" value="@Model.TitleAr" id="TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="SubTitleAr">Header Subtitle</label>
+                                                <input type="text" class="form-control" name="SubTitleAr" value="@Model.SubTitleAr" id="SubTitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionAr">Header Description</label>
+                                                <textarea rows="5" name="DescriptionAr" class="form-control w-100">@Model.DescriptionAr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="SecondTitleAr">Feature Title</label>
+                                                <input type="text" name="SecondTitleAr" class="form-control" value="@Model.SecondTitleAr" id="SecondTitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="SecondSubTitleAr">Feature Subtitle</label>
+                                                <input type="text" class="form-control" name="SecondSubTitleAr" value="@Model.SecondSubTitleAr" id="SecondSubTitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="SecondDescriptionAr">Feature Description</label>
+                                                <textarea rows="5" name="SecondDescriptionAr" class="form-control w-100">@Model.SecondDescriptionAr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ThirdTitleAr">FAQ Title</label>
+                                                <input type="text" name="ThirdTitleAr" class="form-control" value="@Model.ThirdTitleAr" id="ThirdTitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ThirdSubTitleAr">FAQ Subtitle</label>
+                                                <input type="text" class="form-control" name="ThirdSubTitleAr" value="@Model.ThirdSubTitleAr" id="ThirdSubTitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ForthTitleAr">Bottom Paragraph Title</label>
+                                                <input type="text" name="ForthTitleAr" class="form-control" value="@Model.ForthTitleAr" id="ForthTitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ForthSubTitleAr">Bottom Paragraph Subtitle</label>
+                                                <input type="text" class="form-control" name="ForthSubTitleAr" value="@Model.ForthSubTitleAr" id="ForthSubTitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ForthDescriptionAr">Bottom Paragraph Description</label>
+                                                <textarea rows="5" name="ForthDescriptionAr" class="form-control w-100">@Model.ForthDescriptionAr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="LogoTitleAr">Logo Title</label>
+                                                <input type="text" name="LogoTitleAr" class="form-control" value="@Model.LogoTitleAr" id="LogoTitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="LogoSubTitleAr">Logo Subtitle</label>
+                                                <input type="text" class="form-control" name="LogoSubTitleAr" value="@Model.LogoSubTitleAr" id="LogoSubTitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="LogoDescriptionAr">Logo Description</label>
+                                                <textarea rows="5" name="LogoDescriptionAr" class="form-control w-100">@Model.LogoDescriptionAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Header Title</label>
+                                                <input type="text" name="TitleUr" class="form-control" value="@Model.TitleUr" id="TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="SubTitleUr">Header Subtitle</label>
+                                                <input type="text" class="form-control" name="SubTitleUr" value="@Model.SubTitleUr" id="SubTitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionUr">Header Description</label>
+                                                <textarea rows="5" name="DescriptionUr" class="form-control w-100">@Model.DescriptionUr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="SecondTitleUr">Feature Title</label>
+                                                <input type="text" name="SecondTitleUr" class="form-control" value="@Model.SecondTitleUr" id="SecondTitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="SecondSubTitleUr">Feature Subtitle</label>
+                                                <input type="text" class="form-control" name="SecondSubTitleUr" value="@Model.SecondSubTitleUr" id="SecondSubTitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="SecondDescriptionUr">Feature Description</label>
+                                                <textarea rows="5" name="SecondDescriptionUr" class="form-control w-100">@Model.SecondDescriptionUr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ThirdTitleUr">FAQ Title</label>
+                                                <input type="text" name="ThirdTitleUr" class="form-control" value="@Model.ThirdTitleUr" id="ThirdTitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ThirdSubTitleUr">FAQ Subtitle</label>
+                                                <input type="text" class="form-control" name="ThirdSubTitleUr" value="@Model.ThirdSubTitleUr" id="ThirdSubTitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ForthTitleUr">Bottom Paragraph Title</label>
+                                                <input type="text" name="ForthTitleUr" class="form-control" value="@Model.ForthTitleUr" id="ForthTitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ForthSubTitleUr">Bottom Paragraph Subtitle</label>
+                                                <input type="text" class="form-control" name="ForthSubTitleUr" value="@Model.ForthSubTitleUr" id="ForthSubTitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ForthDescriptionUr">Bottom Paragraph Description</label>
+                                                <textarea rows="5" name="ForthDescriptionUr" class="form-control w-100">@Model.ForthDescriptionUr</textarea>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="LogoTitleUr">Logo Title</label>
+                                                <input type="text" name="LogoTitleUr" class="form-control" value="@Model.LogoTitleUr" id="LogoTitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="LogoSubTitleUr">Logo Subtitle</label>
+                                                <input type="text" class="form-control" name="LogoSubTitleUr" value="@Model.LogoSubTitleUr" id="LogoSubTitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="LogoDescriptionUr">Logo Description</label>
+                                                <textarea rows="5" name="LogoDescriptionUr" class="form-control w-100">@Model.LogoDescriptionUr</textarea>
+                                            </div>
+                                        </div>
                                     </div>
                                     <div class="form-group ">
                                         <div class="text-center">
@@ -42,18 +270,6 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="form-group">
-                                        <label for="SecondTitle">عنوان ویژگی های نرم افزار</label>
-                                        <input type="text" name="SecondTitle" class="form-control" value="@Model.SecondTitle" id="SecondTitle" placeholder="عنوان ویژگی های نرم افزار را وارد کنید">
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="SecondSubTitle">زیر عنوان ویژگی های نرم افزار</label>
-                                        <input type="text" class="form-control" name="SecondSubTitle" value="@Model.SecondSubTitle" id="SecondSubTitle" placeholder="زیر عنوان ویژگی های نرم افزار را وارد کنید">
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="SecondDescription">توضیحات ویژگی های نرم افزار</label>
-                                        <textarea rows="5" name="SecondDescription" class="form-control w-100" name="SecondDescription">@Model.SecondDescription</textarea>
-                                    </div>
                                     <div class="form-group ">
                                         <div class="text-center">
                                             <img id="downloadPreview" class="thumbnail my-5 w-50 mx-auto" src="~/Images/Site/@Model.DownloadImageName" />
@@ -65,42 +281,8 @@
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="form-group">
-                                        <label for="ThirdTitle">عنوان سوالات متداول</label>
-                                        <input type="text" name="ThirdTitle" class="form-control" value="@Model.ThirdTitle" id="ThirdTitle" placeholder="عنوان سوالات متداول را وارد کنید">
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="ThirdSubTitle">زیر عنوان سوالات متداول</label>
-                                        <input type="text" class="form-control" name="ThirdSubTitle" value="@Model.ThirdSubTitle" id="ThirdSubTitle" placeholder="زیر عنوان سوالات متداول را وارد کنید">
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="ForthTitle">عنوان پاراگراف پایین دانلود باکس</label>
-                                        <input type="text" name="ForthTitle" class="form-control" value="@Model.ForthTitle" id="ForthTitle" placeholder="عنوان پاراگراف پایین دانلود باکس را وارد کنید">
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="ForthSubTitle">زیر عنوان پاراگراف پایین دانلود باکس</label>
-                                        <input type="text" class="form-control" name="ForthSubTitle" value="@Model.ForthSubTitle" id="ForthSubTitle" placeholder="زیر عنوان پاراگراف پایین دانلود باکس را وارد کنید">
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="ForthDescription">توضیحات پاراگراف پایین دانلود باکس</label>
-                                        <textarea rows="5" name="ForthDescription" class="form-control w-100" name="ForthDescription">@Model.ForthDescription</textarea>
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="LogoTitle">عنوان بخش لوگو</label>
-                                        <input type="text" name="LogoTitle" class="form-control" value="@Model.LogoTitle" id="LogoTitle" placeholder="عنوان بخش لوگو را وارد کنید">
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="LogoSubTitle">زیر عنوان بخش لوگو</label>
-                                        <input type="text" class="form-control" name="LogoSubTitle" value="@Model.LogoSubTitle" id="LogoSubTitle" placeholder="زیر عنوان بخش لوگو را وارد کنید">
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="LogoDescription">توضیحات بخش لوگو</label>
-                                        <textarea rows="5" name="LogoDescription" class="form-control w-100" name="LogoDescription">@Model.LogoDescription</textarea>
-                                    </div>
-
                                 </div>
                                 <!-- /.card-body -->
-
                                 <div class="card-footer">
                                     <button type="submit" class="btn btn-warning">ثبت</button>
                                 </div>

--- a/Twelve/Areas/Admin/Views/Home/AppMenuContent.cshtml
+++ b/Twelve/Areas/Admin/Views/Home/AppMenuContent.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.FeaturesContent
+﻿@model ViewModels.FeaturesContentCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">

--- a/Twelve/Areas/Admin/Views/Home/ContactUsContent.cshtml
+++ b/Twelve/Areas/Admin/Views/Home/ContactUsContent.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.ContactUsContent
+﻿@model ViewModels.ContactUsContentCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">

--- a/Twelve/Areas/Admin/Views/Home/FaqContent.cshtml
+++ b/Twelve/Areas/Admin/Views/Home/FaqContent.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.FaqContent
+﻿@model ViewModels.FaqContentCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">

--- a/Twelve/Areas/Admin/Views/Home/IndexContent.cshtml
+++ b/Twelve/Areas/Admin/Views/Home/IndexContent.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.IndexContent
+﻿@model ViewModels.IndexContentCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -16,43 +16,167 @@
                     <form role="form" method="post" enctype="multipart/form-data">
                         <input type="hidden" name="IndexContentId" id="IndexContentId" value="@Model.IndexContentId" />
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="AboutTitle">عنوان درباره ما</label>
-                                <input type="text" name="AboutTitle" class="form-control" value="@Model.AboutTitle" id="AboutTitle" placeholder="عنوان درباره ما را وارد کنید">
+                            <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                            </ul>
+                            <div class="tab-content p-3" id="langTabContent">
+                                <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="AboutTitle">عنوان درباره ما</label>
+                                        <input type="text" name="AboutTitle" class="form-control" value="@Model.AboutTitle" id="AboutTitle" placeholder="عنوان درباره ما را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="AboutSubTitle">زیر عنوان درباره ما</label>
+                                        <input type="text" class="form-control" name="AboutSubTitle" value="@Model.AboutSubTitle" id="AboutSubTitle" placeholder="زیر عنوان درباره ما را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="AboutDescription">توضیحات درباره ما</label>
+                                        <textarea rows="5" name="AboutDescription" class="form-control w-100">@Model.AboutDescription</textarea>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FeatureTitle">عنوان ویژگی های نرم افزار</label>
+                                        <input type="text" name="FeatureTitle" class="form-control" value="@Model.FeatureTitle" id="FeatureTitle" placeholder="عنوان ویژگی های نرم افزار را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FeatureSubTitle">زیر عنوان ویژگی های نرم افزار</label>
+                                        <input type="text" class="form-control" name="FeatureSubTitle" value="@Model.FeatureSubTitle" id="FeatureSubTitle" placeholder="زیر عنوان ویژگی های نرم افزار را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FeatureDescription">توضیحات ویژگی های نرم افزار</label>
+                                        <textarea rows="5" name="FeatureDescription" class="form-control w-100">@Model.FeatureDescription</textarea>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FaqTitle">عنوان سوالات متداول</label>
+                                        <input type="text" name="FaqTitle" class="form-control" value="@Model.FaqTitle" id="FaqTitle" placeholder="عنوان سوالات متداول را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FaqSubTitle">زیر عنوان سوالات متداول</label>
+                                        <input type="text" class="form-control" name="FaqSubTitle" value="@Model.FaqSubTitle" id="FaqSubTitle" placeholder="زیر عنوان سوالات متداول را وارد کنید">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FaqDescription">توضیحات سوالات متداول</label>
+                                        <textarea rows="5" name="FaqDescription" class="form-control w-100">@Model.FaqDescription</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="en" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="AboutTitleEn">About Title</label>
+                                        <input type="text" name="AboutTitleEn" class="form-control" value="@Model.AboutTitleEn" id="AboutTitleEn">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="AboutSubTitleEn">About Subtitle</label>
+                                        <input type="text" class="form-control" name="AboutSubTitleEn" value="@Model.AboutSubTitleEn" id="AboutSubTitleEn">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="AboutDescriptionEn">About Description</label>
+                                        <textarea rows="5" name="AboutDescriptionEn" class="form-control w-100">@Model.AboutDescriptionEn</textarea>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FeatureTitleEn">Feature Title</label>
+                                        <input type="text" name="FeatureTitleEn" class="form-control" value="@Model.FeatureTitleEn" id="FeatureTitleEn">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FeatureSubTitleEn">Feature Subtitle</label>
+                                        <input type="text" class="form-control" name="FeatureSubTitleEn" value="@Model.FeatureSubTitleEn" id="FeatureSubTitleEn">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FeatureDescriptionEn">Feature Description</label>
+                                        <textarea rows="5" name="FeatureDescriptionEn" class="form-control w-100">@Model.FeatureDescriptionEn</textarea>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FaqTitleEn">FAQ Title</label>
+                                        <input type="text" name="FaqTitleEn" class="form-control" value="@Model.FaqTitleEn" id="FaqTitleEn">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FaqSubTitleEn">FAQ Subtitle</label>
+                                        <input type="text" class="form-control" name="FaqSubTitleEn" value="@Model.FaqSubTitleEn" id="FaqSubTitleEn">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FaqDescriptionEn">FAQ Description</label>
+                                        <textarea rows="5" name="FaqDescriptionEn" class="form-control w-100">@Model.FaqDescriptionEn</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ar" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="AboutTitleAr">About Title</label>
+                                        <input type="text" name="AboutTitleAr" class="form-control" value="@Model.AboutTitleAr" id="AboutTitleAr">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="AboutSubTitleAr">About Subtitle</label>
+                                        <input type="text" class="form-control" name="AboutSubTitleAr" value="@Model.AboutSubTitleAr" id="AboutSubTitleAr">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="AboutDescriptionAr">About Description</label>
+                                        <textarea rows="5" name="AboutDescriptionAr" class="form-control w-100">@Model.AboutDescriptionAr</textarea>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FeatureTitleAr">Feature Title</label>
+                                        <input type="text" name="FeatureTitleAr" class="form-control" value="@Model.FeatureTitleAr" id="FeatureTitleAr">
+                                    </div>
+    
+                                    <div class="form-group">
+                                        <label for="FeatureSubTitleAr">Feature Subtitle</label>
+                                        <input type="text" class="form-control" name="FeatureSubTitleAr" value="@Model.FeatureSubTitleAr" id="FeatureSubTitleAr">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FeatureDescriptionAr">Feature Description</label>
+                                        <textarea rows="5" name="FeatureDescriptionAr" class="form-control w-100">@Model.FeatureDescriptionAr</textarea>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FaqTitleAr">FAQ Title</label>
+                                        <input type="text" name="FaqTitleAr" class="form-control" value="@Model.FaqTitleAr" id="FaqTitleAr">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FaqSubTitleAr">FAQ Subtitle</label>
+                                        <input type="text" class="form-control" name="FaqSubTitleAr" value="@Model.FaqSubTitleAr" id="FaqSubTitleAr">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FaqDescriptionAr">FAQ Description</label>
+                                        <textarea rows="5" name="FaqDescriptionAr" class="form-control w-100">@Model.FaqDescriptionAr</textarea>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade" id="ur" role="tabpanel">
+                                    <div class="form-group">
+                                        <label for="AboutTitleUr">About Title</label>
+                                        <input type="text" name="AboutTitleUr" class="form-control" value="@Model.AboutTitleUr" id="AboutTitleUr">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="AboutSubTitleUr">About Subtitle</label>
+                                        <input type="text" class="form-control" name="AboutSubTitleUr" value="@Model.AboutSubTitleUr" id="AboutSubTitleUr">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="AboutDescriptionUr">About Description</label>
+                                        <textarea rows="5" name="AboutDescriptionUr" class="form-control w-100">@Model.AboutDescriptionUr</textarea>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FeatureTitleUr">Feature Title</label>
+                                        <input type="text" name="FeatureTitleUr" class="form-control" value="@Model.FeatureTitleUr" id="FeatureTitleUr">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FeatureSubTitleUr">Feature Subtitle</label>
+                                        <input type="text" class="form-control" name="FeatureSubTitleUr" value="@Model.FeatureSubTitleUr" id="FeatureSubTitleUr">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FeatureDescriptionUr">Feature Description</label>
+                                        <textarea rows="5" name="FeatureDescriptionUr" class="form-control w-100">@Model.FeatureDescriptionUr</textarea>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FaqTitleUr">FAQ Title</label>
+                                        <input type="text" name="FaqTitleUr" class="form-control" value="@Model.FaqTitleUr" id="FaqTitleUr">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FaqSubTitleUr">FAQ Subtitle</label>
+                                        <input type="text" class="form-control" name="FaqSubTitleUr" value="@Model.FaqSubTitleUr" id="FaqSubTitleUr">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="FaqDescriptionUr">FAQ Description</label>
+                                        <textarea rows="5" name="FaqDescriptionUr" class="form-control w-100">@Model.FaqDescriptionUr</textarea>
+                                    </div>
+                                </div>
                             </div>
-                            <div class="form-group">
-                                <label for="AboutSubTitle">زیر عنوان درباره ما</label>
-                                <input type="text" class="form-control" name="AboutSubTitle" value="@Model.AboutSubTitle" id="AboutSubTitle" placeholder="زیر عنوان درباره ما را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="AboutDescription">توضیحات درباره ما</label>
-                                <textarea rows="5" name="AboutDescription" class="form-control w-100" name="AboutDescription">@Model.AboutDescription</textarea>
-                            </div>
-                            <div class="form-group">
-                                <label for="FeatureTitle">عنوان ویژگی های نرم افزار</label>
-                                <input type="text" name="FeatureTitle" class="form-control" value="@Model.FeatureTitle" id="FeatureTitle" placeholder="عنوان ویژگی های نرم افزار را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="FeatureSubTitle">زیر عنوان ویژگی های نرم افزار</label>
-                                <input type="text" class="form-control" name="FeatureSubTitle" value="@Model.FeatureSubTitle" id="FeatureSubTitle" placeholder="زیر عنوان ویژگی های نرم افزار را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="FeatureDescription">توضیحات ویژگی های نرم افزار</label>
-                                <textarea rows="5" name="FeatureDescription" class="form-control w-100" name="FeatureDescription">@Model.FeatureDescription</textarea>
-                            </div>
-                            <div class="form-group">
-                                <label for="FaqTitle">عنوان سوالات متداول</label>
-                                <input type="text" name="FaqTitle" class="form-control" value="@Model.FaqTitle" id="FaqTitle" placeholder="عنوان سوالات متداول را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="FaqSubTitle">زیر عنوان سوالات متداول</label>
-                                <input type="text" class="form-control" name="FaqSubTitle" value="@Model.FaqSubTitle" id="FaqSubTitle" placeholder="زیر عنوان سوالات متداول را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="FaqDescription">توضیحات سوالات متداول</label>
-                                <textarea rows="5" name="FaqDescription" class="form-control w-100" name="FaqDescription">@Model.FaqDescription</textarea>
-                            </div>
-
                         </div>
                         <!-- /.card-body -->
 

--- a/Twelve/Areas/Admin/Views/Introduces/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/Introduces/Create.cshtml
@@ -16,13 +16,54 @@
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-9">
-                                    <div class="form-group">
-                                        <label for="Title">عنوان</label>
-                                        <input type="text" class="form-control w-100" name="Title" id="Title" placeholder="عنوان را وارد کنید" />
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="Description">توضیح کوتاه</label>
-                                        <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="توضیح کوتاه را وارد کنید"></textarea>
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" class="form-control w-100" name="Title" id="Title" placeholder="عنوان را وارد کنید" />
+                                            </div>
+        
+                                            <div class="form-group">
+                                                <label for="Description">توضیح کوتاه</label>
+                                                <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="توضیح کوتاه را وارد کنید"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleEn" id="TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionEn">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionEn" id="DescriptionEn"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleAr" id="TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionAr">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionAr" id="DescriptionAr"></textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleUr" id="TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionUr">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionUr" id="DescriptionUr"></textarea>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                                 <div class="col-3">

--- a/Twelve/Areas/Admin/Views/Introduces/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/Introduces/Update.cshtml
@@ -17,13 +17,53 @@
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-9">
-                                    <div class="form-group">
-                                        <label for="Title">عنوان</label>
-                                        <input type="text" class="form-control w-100" value="@Model.Title" name="Title" id="Title" placeholder="عنوان را وارد کنید" />
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="Description">توضیح کوتاه</label>
-                                        <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="توضیح کوتاه را وارد کنید">@Model.Description</textarea>
+                                    <ul class="nav nav-tabs" id="langTab" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" id="fa-tab" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="en-tab" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ar-tab" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" id="ur-tab" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3" id="langTabContent">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" class="form-control w-100" value="@Model.Title" name="Title" id="Title" placeholder="عنوان را وارد کنید" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="Description">توضیح کوتاه</label>
+                                                <textarea rows="5" class="form-control w-100" name="Description" id="Description" placeholder="توضیح کوتاه را وارد کنید">@Model.Description</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleEn" id="TitleEn" value="@Model.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionEn">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionEn" id="DescriptionEn">@Model.DescriptionEn</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleAr" id="TitleAr" value="@Model.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionAr">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionAr" id="DescriptionAr">@Model.DescriptionAr</textarea>
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control w-100" name="TitleUr" id="TitleUr" value="@Model.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="DescriptionUr">Short Description</label>
+                                                <textarea rows="5" class="form-control w-100" name="DescriptionUr" id="DescriptionUr">@Model.DescriptionUr</textarea>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                                 <div class="col-3">

--- a/Twelve/Areas/Admin/Views/Sliders/Create.cshtml
+++ b/Twelve/Areas/Admin/Views/Sliders/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.Slider
+@model ViewModels.SliderCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -13,19 +13,63 @@
                     <!-- /.card-header -->
                     <!-- form start -->
                     <form role="form" method="post" enctype="multipart/form-data">
-                        <input type="hidden" name="SliderGroupID" id="SliderGroupID" value="@ViewBag.GroupID" />
+                        <input type="hidden" name="SliderGroupId" id="SliderGroupId" value="@Model.SliderGroupId" />
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" id="Title" placeholder="عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="ShortDescription">توضیح کوتاه</label>
-                                <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                            <div class="row">
+                                <div class="col-12">
+                                    <ul class="nav nav-tabs" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" name="Title" class="form-control" id="Title" value="@Model?.Title" placeholder="عنوان را وارد کنید">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescription">توضیح کوتاه</label>
+                                                <input type="text" class="form-control" name="ShortDescription" id="ShortDescription" value="@Model?.ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model?.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionEn">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionEn" id="ShortDescriptionEn" value="@Model?.ShortDescriptionEn" />
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model?.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionAr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionAr" id="ShortDescriptionAr" value="@Model?.ShortDescriptionAr" />
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model?.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionUr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionUr" id="ShortDescriptionUr" value="@Model?.ShortDescriptionUr" />
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group">
                                 <label for="Link">لینک</label>
-                                <input type="text" class="form-control" name="Link" id="Link" placeholder="لینک را وارد کنید">
+                                <input type="text" class="form-control" name="Link" id="Link" value="@Model?.Link" placeholder="لینک را وارد کنید">
                             </div>
                             <div class="form-group ">
                                 <div class="text-center">

--- a/Twelve/Areas/Admin/Views/Sliders/Update.cshtml
+++ b/Twelve/Areas/Admin/Views/Sliders/Update.cshtml
@@ -1,4 +1,4 @@
-﻿@model DataLayer.Slider
+@model ViewModels.SliderCrudViewModel
 <div class="content-header">
     <div class="container-fluid">
         <div class="row">
@@ -17,13 +17,57 @@
                         <input type="hidden" name="SliderGroupId" id="SliderGroupId" value="@Model.SliderGroupId" />
                         <input type="hidden" name="ImageName" id="ImageName" value="@Model.ImageName" />
                         <div class="card-body">
-                            <div class="form-group">
-                                <label for="Title">عنوان</label>
-                                <input type="text" name="Title" class="form-control" value="@Model.Title" id="Title" placeholder="عنوان را وارد کنید">
-                            </div>
-                            <div class="form-group">
-                                <label for="ShortDescription">توضیح کوتاه</label>
-                                <input type="text" class="form-control" name="ShortDescription" value="@Model.ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                            <div class="row">
+                                <div class="col-12">
+                                    <ul class="nav nav-tabs" role="tablist">
+                                        <li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#fa" role="tab">FA</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#en" role="tab">EN</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#ar" role="tab">AR</a></li>
+                                        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#ur" role="tab">UR</a></li>
+                                    </ul>
+                                    <div class="tab-content p-3">
+                                        <div class="tab-pane fade show active" id="fa" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="Title">عنوان</label>
+                                                <input type="text" name="Title" class="form-control" value="@Model.Title" id="Title" placeholder="عنوان را وارد کنید">
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescription">توضیح کوتاه</label>
+                                                <input type="text" class="form-control" name="ShortDescription" value="@Model.ShortDescription" id="ShortDescription" placeholder="توضیح کوتاه را وارد کنید">
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="en" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleEn">Title</label>
+                                                <input type="text" class="form-control" name="TitleEn" id="TitleEn" value="@Model?.TitleEn" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionEn">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionEn" id="ShortDescriptionEn" value="@Model?.ShortDescriptionEn" />
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ar" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleAr">Title</label>
+                                                <input type="text" class="form-control" name="TitleAr" id="TitleAr" value="@Model?.TitleAr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionAr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionAr" id="ShortDescriptionAr" value="@Model?.ShortDescriptionAr" />
+                                            </div>
+                                        </div>
+                                        <div class="tab-pane fade" id="ur" role="tabpanel">
+                                            <div class="form-group">
+                                                <label for="TitleUr">Title</label>
+                                                <input type="text" class="form-control" name="TitleUr" id="TitleUr" value="@Model?.TitleUr" />
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="ShortDescriptionUr">Short Description</label>
+                                                <input type="text" class="form-control" name="ShortDescriptionUr" id="ShortDescriptionUr" value="@Model?.ShortDescriptionUr" />
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                             <div class="form-group">
                                 <label for="Link">لینک</label>

--- a/ViewModels/AboutUsViewModels.cs
+++ b/ViewModels/AboutUsViewModels.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ViewModels
+{
+    public class AboutUsContentCrudViewModel
+    {
+        public int AboutUsContentId { get; set; }
+        public string? SubTitle { get; set; }
+        public string? Title { get; set; }
+        public string? Description { get; set; }
+        public string? ImageName { get; set; }
+        public string? SecondSubTitle { get; set; }
+        public string? SecondTitle { get; set; }
+        public string? SecondDescription { get; set; }
+        public string? ThirdSubTitle { get; set; }
+        public string? ThirdTitle { get; set; }
+        public string? DownloadImageName { get; set; }
+        public string? ForthSubTitle { get; set; }
+        public string? ForthTitle { get; set; }
+        public string? ForthDescription { get; set; }
+        public string? LogoTitle { get; set; }
+        public string? LogoSubTitle { get; set; }
+        public string? LogoDescription { get; set; }
+        public string? SubTitleEn { get; set; }
+        public string? SubTitleAr { get; set; }
+        public string? SubTitleUr { get; set; }
+        public string? TitleEn { get; set; }
+        public string? TitleAr { get; set; }
+        public string? TitleUr { get; set; }
+        public string? DescriptionEn { get; set; }
+        public string? DescriptionAr { get; set; }
+        public string? DescriptionUr { get; set; }
+        public string? SecondSubTitleEn { get; set; }
+        public string? SecondSubTitleAr { get; set; }
+        public string? SecondSubTitleUr { get; set; }
+        public string? SecondTitleEn { get; set; }
+        public string? SecondTitleAr { get; set; }
+        public string? SecondTitleUr { get; set; }
+        public string? SecondDescriptionEn { get; set; }
+        public string? SecondDescriptionAr { get; set; }
+        public string? SecondDescriptionUr { get; set; }
+        public string? ThirdSubTitleEn { get; set; }
+        public string? ThirdSubTitleAr { get; set; }
+        public string? ThirdSubTitleUr { get; set; }
+        public string? ThirdTitleEn { get; set; }
+        public string? ThirdTitleAr { get; set; }
+        public string? ThirdTitleUr { get; set; }
+        public string? ForthSubTitleEn { get; set; }
+        public string? ForthSubTitleAr { get; set; }
+        public string? ForthSubTitleUr { get; set; }
+        public string? ForthTitleEn { get; set; }
+        public string? ForthTitleAr { get; set; }
+        public string? ForthTitleUr { get; set; }
+        public string? ForthDescriptionEn { get; set; }
+        public string? ForthDescriptionAr { get; set; }
+        public string? ForthDescriptionUr { get; set; }
+        public string? LogoTitleEn { get; set; }
+        public string? LogoTitleAr { get; set; }
+        public string? LogoTitleUr { get; set; }
+        public string? LogoSubTitleEn { get; set; }
+        public string? LogoSubTitleAr { get; set; }
+        public string? LogoSubTitleUr { get; set; }
+        public string? LogoDescriptionEn { get; set; }
+        public string? LogoDescriptionAr { get; set; }
+        public string? LogoDescriptionUr { get; set; }
+    }
+
+    public class AboutUsSightCrudViewModel
+    {
+        public int AboutUsSightId { get; set; }
+        public string SightTitle { get; set; }
+        public string SightDescription { get; set; }
+        public string ImageName { get; set; }
+        public string SightTitleEn { get; set; }
+        public string SightTitleAr { get; set; }
+        public string SightTitleUr { get; set; }
+        public string SightDescriptionEn { get; set; }
+        public string SightDescriptionAr { get; set; }
+        public string SightDescriptionUr { get; set; }
+    }
+
+    public class AboutUsArticleCrudViewModel
+    {
+        public int AboutUsArticleId { get; set; }
+        public string Title { get; set; }
+        public string SubTitle { get; set; }
+        public string Description { get; set; }
+        public string ImageName { get; set; }
+        public string TitleEn { get; set; }
+        public string TitleAr { get; set; }
+        public string TitleUr { get; set; }
+        public string SubTitleEn { get; set; }
+        public string SubTitleAr { get; set; }
+        public string SubTitleUr { get; set; }
+        public string DescriptionEn { get; set; }
+        public string DescriptionAr { get; set; }
+        public string DescriptionUr { get; set; }
+    }
+
+    public class AboutUsItemCrudViewModel
+    {
+        public int AboutUsItemId { get; set; }
+        public string ItemTitle { get; set; }
+        public string ItemDescription { get; set; }
+        public string ImageName { get; set; }
+        public string ItemTitleEn { get; set; }
+        public string ItemTitleAr { get; set; }
+        public string ItemTitleUr { get; set; }
+        public string ItemDescriptionEn { get; set; }
+        public string ItemDescriptionAr { get; set; }
+        public string ItemDescriptionUr { get; set; }
+    }
+}

--- a/ViewModels/AdvertisementsViewModels.cs
+++ b/ViewModels/AdvertisementsViewModels.cs
@@ -11,5 +11,18 @@ namespace ViewModels
         public int AdvertisementID { get; set; }
         public string ImageName { get; set; }
         public string Link { get; set; }
+        public string Title { get; set; }
+    }
+
+    public class AdvertisementCrudViewModel
+    {
+        public int AdvertisementId { get; set; }
+        public string Title { get; set; }
+        public string TitleEn { get; set; }
+        public string TitleAr { get; set; }
+        public string TitleUr { get; set; }
+        public string Link { get; set; }
+        public bool IsBanner { get; set; }
+        public string ImageName { get; set; }
     }
 }

--- a/ViewModels/BlogViewModels.cs
+++ b/ViewModels/BlogViewModels.cs
@@ -28,6 +28,15 @@ namespace ViewModels
         [Display(Name = "توضیحات")]
         [Required(ErrorMessage = "لطفا {0} را وارد کنید")]
         public string Description { get; set; }
+        public string TitleEn { get; set; }
+        public string TitleAr { get; set; }
+        public string TitleUr { get; set; }
+        public string ShortDescriptionEn { get; set; }
+        public string ShortDescriptionAr { get; set; }
+        public string ShortDescriptionUr { get; set; }
+        public string DescriptionEn { get; set; }
+        public string DescriptionAr { get; set; }
+        public string DescriptionUr { get; set; }
         public string ImageName { get; set; }
         public string Source { get; set; }
         public string Tags { get; set; }
@@ -54,6 +63,21 @@ namespace ViewModels
         public List<BlogCommentViewModel> Comments { get; set; }
         public PaginationViewModel Pagination { get; set; }
         public double PageCount { get; set; }
+    }
+
+    public class BlogGroupCrudViewModel
+    {
+        public int BlogGroupId { get; set; }
+
+        [Display(Name = "عنوان")]
+        [Required(ErrorMessage = "لطفا {0} را وارد کنید")]
+        public string GroupName { get; set; }
+
+        public string GroupNameEn { get; set; }
+        public string GroupNameAr { get; set; }
+        public string GroupNameUr { get; set; }
+
+        public int? ParentId { get; set; }
     }
     public class BlogGroupNameViewModel
     {

--- a/ViewModels/CallInfoViewModels.cs
+++ b/ViewModels/CallInfoViewModels.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,27 +6,21 @@ using System.Threading.Tasks;
 
 namespace ViewModels
 {
-    public class IntroducesPageDataViewModel
+    public class CallInfoCrudViewModel
     {
-        public int IntroduceID { get; set; }
+        public int CallInfoId { get; set; }
         public string Title { get; set; }
+        public string ShortDescription { get; set; }
         public string Description { get; set; }
-        public string Feature { get; set; }
-    }
-
-    public class IntroduceCrudViewModel
-    {
-        public List<FeatureNameViewModel> Features { get; set; }
-        public List<int> SelectedFeature { get; set; }
-        public int IntroduceID { get; set; }
-        public string Title { get; set; }
-        public string Description { get; set; }
-        public string Feature { get; set; }
         public string TitleEn { get; set; }
         public string TitleAr { get; set; }
         public string TitleUr { get; set; }
+        public string ShortDescriptionEn { get; set; }
+        public string ShortDescriptionAr { get; set; }
+        public string ShortDescriptionUr { get; set; }
         public string DescriptionEn { get; set; }
         public string DescriptionAr { get; set; }
         public string DescriptionUr { get; set; }
+        public string ImageName { get; set; }
     }
 }

--- a/ViewModels/FaqsViewModel.cs
+++ b/ViewModels/FaqsViewModel.cs
@@ -11,9 +11,42 @@ namespace ViewModels
         public int FaqID { get; set; }
         public string Question { get; set; }
         public string Answer { get; set; }
+        public string QuestionEn { get; set; }
+        public string QuestionAr { get; set; }
+        public string QuestionUr { get; set; }
+        public string AnswerEn { get; set; }
+        public string AnswerAr { get; set; }
+        public string AnswerUr { get; set; }
         public bool IsMain { get; set; }
         public List<FaqsGroupsItemViewModel> Groups { get; set; }
         public List<int> SelectedGroups { get; set; }
+    }
+
+    public class FaqGroupCrudViewModel
+    {
+        public int FaqGroupId { get; set; }
+        public string GroupName { get; set; }
+        public string GroupNameEn { get; set; }
+        public string GroupNameAr { get; set; }
+        public string GroupNameUr { get; set; }
+        public int? ParentId { get; set; }
+    }
+
+    public class FaqContentCrudViewModel
+    {
+        public int FaqContentId { get; set; }
+        public string FaqContentTitle { get; set; }
+        public string FaqContentSubTitle { get; set; }
+        public string FaqContentDescription { get; set; }
+        public string FaqContentTitleEn { get; set; }
+        public string FaqContentTitleAr { get; set; }
+        public string FaqContentTitleUr { get; set; }
+        public string FaqContentSubTitleEn { get; set; }
+        public string FaqContentSubTitleAr { get; set; }
+        public string FaqContentSubTitleUr { get; set; }
+        public string FaqContentDescriptionEn { get; set; }
+        public string FaqContentDescriptionAr { get; set; }
+        public string FaqContentDescriptionUr { get; set; }
     }
 
     public class FaqsPageDataViewModel

--- a/ViewModels/FeaturesViewModel.cs
+++ b/ViewModels/FeaturesViewModel.cs
@@ -53,4 +53,57 @@ namespace ViewModels
         public string Demo { get; set; }
         public bool IsBig { get; set; }
     }
+
+    public class FeatureCrudViewModel
+    {
+        public int FeatureId { get; set; }
+        public string Title { get; set; }
+        public string ShortDescription { get; set; }
+        public string FirstDescription { get; set; }
+        public string FirstArticleTitle { get; set; }
+        public string FirstArticleDescription { get; set; }
+        public string SecondArticleTitle { get; set; }
+        public string SecondArticleDescription { get; set; }
+        public string TitleEn { get; set; }
+        public string TitleAr { get; set; }
+        public string TitleUr { get; set; }
+        public string ShortDescriptionEn { get; set; }
+        public string ShortDescriptionAr { get; set; }
+        public string ShortDescriptionUr { get; set; }
+        public string FirstDescriptionEn { get; set; }
+        public string FirstDescriptionAr { get; set; }
+        public string FirstDescriptionUr { get; set; }
+        public string FirstArticleTitleEn { get; set; }
+        public string FirstArticleTitleAr { get; set; }
+        public string FirstArticleTitleUr { get; set; }
+        public string FirstArticleDescriptionEn { get; set; }
+        public string FirstArticleDescriptionAr { get; set; }
+        public string FirstArticleDescriptionUr { get; set; }
+        public string SecondArticleTitleEn { get; set; }
+        public string SecondArticleTitleAr { get; set; }
+        public string SecondArticleTitleUr { get; set; }
+        public string SecondArticleDescriptionEn { get; set; }
+        public string SecondArticleDescriptionAr { get; set; }
+        public string SecondArticleDescriptionUr { get; set; }
+        public string ImageName { get; set; }
+        public string AnimateFilename { get; set; }
+        public string FirstArticleImage { get; set; }
+        public string SecondArticleImage { get; set; }
+        public string IntroduceImageName { get; set; }
+    }
+
+    public class FeatureItemCrudViewModel
+    {
+        public int FeaturesItemId { get; set; }
+        public int FeatureId { get; set; }
+        public string Title { get; set; }
+        public string ShortDescription { get; set; }
+        public string TitleEn { get; set; }
+        public string TitleAr { get; set; }
+        public string TitleUr { get; set; }
+        public string ShortDescriptionEn { get; set; }
+        public string ShortDescriptionAr { get; set; }
+        public string ShortDescriptionUr { get; set; }
+        public string ImageName { get; set; }
+    }
 }

--- a/ViewModels/SiteGeneralViewModels.cs
+++ b/ViewModels/SiteGeneralViewModels.cs
@@ -8,6 +8,93 @@ using System.Threading.Tasks;
 namespace ViewModels
 {
 
+    public class IndexContentCrudViewModel
+    {
+        public int IndexContentId { get; set; }
+        public string AboutTitle { get; set; }
+        public string AboutSubTitle { get; set; }
+        public string AboutDescription { get; set; }
+        public string FeatureTitle { get; set; }
+        public string FeatureSubTitle { get; set; }
+        public string FeatureDescription { get; set; }
+        public string FaqTitle { get; set; }
+        public string FaqSubTitle { get; set; }
+        public string FaqDescription { get; set; }
+        public string AboutTitleEn { get; set; }
+        public string AboutTitleAr { get; set; }
+        public string AboutTitleUr { get; set; }
+        public string AboutSubTitleEn { get; set; }
+        public string AboutSubTitleAr { get; set; }
+        public string AboutSubTitleUr { get; set; }
+        public string AboutDescriptionEn { get; set; }
+        public string AboutDescriptionAr { get; set; }
+        public string AboutDescriptionUr { get; set; }
+        public string FeatureTitleEn { get; set; }
+        public string FeatureTitleAr { get; set; }
+        public string FeatureTitleUr { get; set; }
+        public string FeatureSubTitleEn { get; set; }
+        public string FeatureSubTitleAr { get; set; }
+        public string FeatureSubTitleUr { get; set; }
+        public string FeatureDescriptionEn { get; set; }
+        public string FeatureDescriptionAr { get; set; }
+        public string FeatureDescriptionUr { get; set; }
+        public string FaqTitleEn { get; set; }
+        public string FaqTitleAr { get; set; }
+        public string FaqTitleUr { get; set; }
+        public string FaqSubTitleEn { get; set; }
+        public string FaqSubTitleAr { get; set; }
+        public string FaqSubTitleUr { get; set; }
+        public string FaqDescriptionEn { get; set; }
+        public string FaqDescriptionAr { get; set; }
+        public string FaqDescriptionUr { get; set; }
+    }
+
+    public class ContactUsContentCrudViewModel
+    {
+        public int ContactUsContentId { get; set; }
+        public string FirstSubTitle { get; set; }
+        public string FirstTitle { get; set; }
+        public string FristDescription { get; set; }
+        public string SecondSubTitle { get; set; }
+        public string SecondTitle { get; set; }
+        public string SecondDescription { get; set; }
+        public string FirstSubTitleEn { get; set; }
+        public string FirstSubTitleAr { get; set; }
+        public string FirstSubTitleUr { get; set; }
+        public string FirstTitleEn { get; set; }
+        public string FirstTitleAr { get; set; }
+        public string FirstTitleUr { get; set; }
+        public string FristDescriptionEn { get; set; }
+        public string FristDescriptionAr { get; set; }
+        public string FristDescriptionUr { get; set; }
+        public string SecondSubTitleEn { get; set; }
+        public string SecondSubTitleAr { get; set; }
+        public string SecondSubTitleUr { get; set; }
+        public string SecondTitleEn { get; set; }
+        public string SecondTitleAr { get; set; }
+        public string SecondTitleUr { get; set; }
+        public string SecondDescriptionEn { get; set; }
+        public string SecondDescriptionAr { get; set; }
+        public string SecondDescriptionUr { get; set; }
+    }
+
+    public class FeaturesContentCrudViewModel
+    {
+        public int FeatureContentId { get; set; }
+        public string FeaturesTitle { get; set; }
+        public string FeatruesSubTitle { get; set; }
+        public string FeaturesDescription { get; set; }
+        public string FeaturesTitleEn { get; set; }
+        public string FeaturesTitleAr { get; set; }
+        public string FeaturesTitleUr { get; set; }
+        public string FeatruesSubTitleEn { get; set; }
+        public string FeatruesSubTitleAr { get; set; }
+        public string FeatruesSubTitleUr { get; set; }
+        public string FeaturesDescriptionEn { get; set; }
+        public string FeaturesDescriptionAr { get; set; }
+        public string FeaturesDescriptionUr { get; set; }
+    }
+
     public class SeoTagsViewModel
     {
         public int BlogID { get; set; }

--- a/ViewModels/SlidersViewModels.cs
+++ b/ViewModels/SlidersViewModels.cs
@@ -21,4 +21,20 @@ namespace ViewModels
         public List<IndexSliderItemViewModel> Desktop { get; set; }
         public List<IndexSliderItemViewModel> Mobile { get; set; }
     }
+
+    public class SliderCrudViewModel
+    {
+        public int SliderId { get; set; }
+        public int SliderGroupId { get; set; }
+        public string Title { get; set; }
+        public string ShortDescription { get; set; }
+        public string TitleEn { get; set; }
+        public string TitleAr { get; set; }
+        public string TitleUr { get; set; }
+        public string ShortDescriptionEn { get; set; }
+        public string ShortDescriptionAr { get; set; }
+        public string ShortDescriptionUr { get; set; }
+        public string Link { get; set; }
+        public string ImageName { get; set; }
+    }
 }


### PR DESCRIPTION
## Summary
- Simplify FAQ group selection UI and localize FAQ list results
- Add language-specific fields, repository saves, and controller hooks for Introduces
- Provide FA/EN/AR/UR tabs for Introduces and index-content admin forms
- Localize About-Us content and CRUD pages with new translation-aware view models and repository methods
- Add translation management for sliders, call info, and advertisements with language-tabbed admin editors

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(package not found)*


------
https://chatgpt.com/codex/tasks/task_e_688e95d3bfc48327bc0f6b96509ee7ca